### PR TITLE
Add section data and configuration plane

### DIFF
--- a/core/constants.lua
+++ b/core/constants.lua
@@ -247,6 +247,11 @@ const.TRADESKILL_MAP = {
 	[19] = GetItemSubClassInfo(Enum.ItemClass.Tradegoods, 19), -- "Finishing Reagents"
 }
 
+---@class CustomCategoryFilter
+---@field enabled boolean
+---@field itemList table<number, boolean>
+---@field readOnly boolean
+
 ---@class databaseOptions
 const.DATABASE_DEFAULTS = {
   profile = {
@@ -355,6 +360,8 @@ const.DATABASE_DEFAULTS = {
       [const.BAG_KIND.BACKPACK] = const.BAG_VIEW.SECTION_GRID,
       [const.BAG_KIND.BANK] = const.BAG_VIEW.SECTION_GRID,
     },
+    ---@type table<string, CustomCategoryFilter>
+    customCategoryFilters = {},
     categoryFilters = {
       [const.BAG_KIND.BACKPACK] = {
         Type = true,

--- a/core/database.lua
+++ b/core/database.lua
@@ -159,4 +159,40 @@ function DB:SetItemSortType(kind, view, sort)
   DB.data.profile.itemSort[kind][view] = sort
 end
 
+---@param itemID number
+---@param category string
+function DB:SaveItemToCategory(itemID, category)
+  DB.data.profile.customCategoryFilters[category] = DB.data.profile.customCategoryFilters[category] or {itemList = {}}
+  DB.data.profile.customCategoryFilters[category].itemList[itemID] = true
+end
+
+---@param category string
+---@param enabled boolean
+function DB:SetItemCategoryEnabled(category, enabled)
+  DB.data.profile.customCategoryFilters[category].enabled = enabled
+end
+
+---@param category string
+function DB:DeleteItemCategory(category)
+  DB.data.profile.customCategoryFilters[category] = nil
+end
+
+---@param category string
+function DB:WipeItemCategory(category)
+  if DB.data.profile.customCategoryFilters[category] then
+    DB.data.profile.customCategoryFilters[category].itemList = {}
+  end
+end
+
+---@return table<string, CustomCategoryFilter>
+function DB:GetAllItemCategories()
+  return DB.data.profile.customCategoryFilters
+end
+
+---@param category string
+---@return CustomCategoryFilter
+function DB:GetItemCategory(category)
+  return DB.data.profile.customCategoryFilters[category]
+end
+
 DB:Enable()

--- a/core/init.lua
+++ b/core/init.lua
@@ -128,9 +128,11 @@ function addon:OnEnable()
    end
   end)
 
+  events:RegisterMessage('categories/Changed', function()
+    addon.Bags.Backpack:UpdateContextMenu()
+    addon.Bags.Bank:UpdateContextMenu()
+  end)
+
   debug:Log("init", "about refresh all items")
   items:RefreshBackpack()
-  categories:AddItemToCategory(6948, L:G("Hearthstone"))
-  categories:AddItemToCategory(202046, L:G("Hearthstone"))
-  addon.Bags.Backpack:UpdateContextMenu()
 end

--- a/core/init.lua
+++ b/core/init.lua
@@ -31,6 +31,9 @@ local masque = addon:GetModule('Masque')
 ---@class SectionFrame: AceModule
 local sectionFrame = addon:GetModule('SectionFrame')
 
+---@class Categories: AceModule
+local categories = addon:GetModule('Categories')
+
 ---@class Context: AceModule
 local context = addon:GetModule('Context')
 
@@ -95,6 +98,7 @@ function addon:OnEnable()
   masque:Enable()
   context:Enable()
   items:Enable()
+  categories:Enable()
   self:HideBlizzardBags()
 
   addon.Bags.Backpack = BagFrame:Create(const.BAG_KIND.BACKPACK)
@@ -116,14 +120,16 @@ function addon:OnEnable()
     addon.Bags.Backpack:Draw(itemData)
    end)
 
-   events:RegisterMessage('items/RefreshBank/Done', function(_, itemData)
-    debug:Log("init/OnInitialize/items", "Drawing bank")
-    addon.Bags.Bank:Draw(itemData)
-    if not addon.Bags.Bank:IsShown() then
-      addon.Bags.Bank:Show()
-    end
-   end)
+  events:RegisterMessage('items/RefreshBank/Done', function(_, itemData)
+   debug:Log("init/OnInitialize/items", "Drawing bank")
+   addon.Bags.Bank:Draw(itemData)
+   if not addon.Bags.Bank:IsShown() then
+     addon.Bags.Bank:Show()
+   end
+  end)
 
-   debug:Log("init", "about refresh all items")
-   items:RefreshBackpack()
+  debug:Log("init", "about refresh all items")
+  items:RefreshBackpack()
+  categories:AddItemToCategory(6948, L:G("Hearthstone"))
+  addon.Bags.Backpack:UpdateContextMenu()
 end

--- a/core/init.lua
+++ b/core/init.lua
@@ -131,5 +131,6 @@ function addon:OnEnable()
   debug:Log("init", "about refresh all items")
   items:RefreshBackpack()
   categories:AddItemToCategory(6948, L:G("Hearthstone"))
+  categories:AddItemToCategory(202046, L:G("Hearthstone"))
   addon.Bags.Backpack:UpdateContextMenu()
 end

--- a/data/categories.lua
+++ b/data/categories.lua
@@ -11,6 +11,7 @@ local items = addon:GetModule('Items')
 ---@field private functionCategories table<number, string>
 ---@field private itemsWithNoCategory table<number, boolean>
 ---@field private categoryFunctions table<string, fun(data: ItemData): string>
+---@field private categoryList table<string, boolean>
 local categories = addon:NewModule('Categories')
 
 function categories:OnInitialize()
@@ -18,6 +19,13 @@ function categories:OnInitialize()
   self.functionCategories = {}
   self.categoryFunctions = {}
   self.itemsWithNoCategory = {}
+  self.categoryList = {}
+end
+
+-- GetAllCategories returns a list of all custom categories.
+---@return table<string, boolean>
+function categories:GetAllCategories()
+  return self.categoryList
 end
 
 -- AddItemToCategory adds an item to a custom category by its ItemID.
@@ -25,6 +33,7 @@ end
 ---@param category string The name of the custom category to add the item to.
 function categories:AddItemToCategory(id, category)
   self.itemToCategory[id] = category
+  self.categoryList[category] = true
 end
 
 -- GetCustomCategory returns the custom category for an item, or nil if it doesn't have one.
@@ -88,5 +97,3 @@ function categories:ReprocessAllItems()
   wipe(self.functionCategories)
   items:RefreshAll()
 end
-
-categories:Enable()

--- a/data/categories.lua
+++ b/data/categories.lua
@@ -75,11 +75,23 @@ function categories:GetCustomCategory(data)
 
   -- Check for categories manually set by item.
   local category = self.itemToCategory[itemID]
-  if category then return category end
+  if category then
+    if self:IsCategoryEnabled(category) then
+      return category
+    else
+      return nil
+    end
+  end
 
   -- Check for categories set by registered functions.
   category = self.functionCategories[itemID]
-  if category then return category end
+  if category then
+    if self:IsCategoryEnabled(category) then
+      return category
+    else
+      return nil
+    end
+  end
 
   -- Check for items that had no category previously. This
   -- is a performance optimization to avoid calling all
@@ -92,7 +104,11 @@ function categories:GetCustomCategory(data)
       self.functionCategories[itemID] = category
       self.categoryList[category] = self.categoryList[category] or {}
       table.insert(self.categoryList[category], itemID)
-      return category
+      if self:IsCategoryEnabled(category) then
+        return category
+      else
+        return nil
+      end
     end
   end
   self.itemsWithNoCategory[itemID] = true

--- a/frames/bag.lua
+++ b/frames/bag.lua
@@ -77,6 +77,7 @@ local Window = LibStub('LibWindow-1.1')
 ---@field moneyFrame Money
 ---@field resizeHandle Button
 ---@field drawOnClose boolean
+---@field menuList MenuList[]
 local bagProto = {}
 
 function bagProto:Show()
@@ -264,6 +265,10 @@ function bagProto:OnCooldown()
   end
 end
 
+function bagProto:UpdateContextMenu()
+  self.menuList = context:CreateContextMenu(self)
+end
+
 -------
 --- Bag Frame
 -------
@@ -327,7 +332,7 @@ function bagFrame:Create(kind)
   end
 
   -- Setup the context menu.
-  local contextMenu = context:CreateContextMenu(b)
+  b.menuList = context:CreateContextMenu(b)
 
   -- Create the invisible menu button.
   local bagButton = CreateFrame("Button")
@@ -383,7 +388,7 @@ function bagFrame:Create(kind)
         anig:SetLooping("NONE")
         anig:Restart()
       end
-      context:Show(contextMenu)
+      context:Show(b.menuList)
     else
       b:ToggleReagentBank()
     end

--- a/frames/context.lua
+++ b/frames/context.lua
@@ -16,6 +16,9 @@ local database = addon:GetModule('Database')
 ---@class SliderFrame: AceModule
 local slider = addon:GetModule('Slider')
 
+---@class Categories: AceModule
+local categories = addon:GetModule('Categories')
+
 ---@class Localization: AceModule
 local L =  addon:GetModule('Localization')
 
@@ -55,6 +58,27 @@ end
 
 function context:Hide()
   LibDD:HideDropDownMenu(1)
+end
+
+local function addDivider(menuList)
+  table.insert(menuList, {
+    text = "",
+    isTitle = true,
+    hasArrow = false,
+    notCheckable = true,
+    iconOnly = true,
+    isUninteractable = true,
+    icon = "Interface\\Common\\UI-TooltipDivider-Transparent",
+    iconInfo = {
+      tCoordLeft = 0,
+			tCoordRight = 1,
+			tCoordTop = 0,
+			tCoordBottom = 1,
+			tSizeX = 0,
+			tSizeY = 8,
+			tFitDropDownSizeX = true
+    },
+  })
 end
 
 ---@param menu MenuList[]
@@ -124,7 +148,27 @@ function context:CreateContextMenu(bag)
       }
     }
   })
-
+  addDivider(menuList[2].menuList)
+  for category, _ in pairs(categories:GetAllCategories()) do
+    table.insert(menuList[2].menuList, {
+      text = category,
+      tooltipTitle = category,
+      tooltipText = L:G("If enabled, will categorize items by ") .. category .. ".",
+      checked = function() return database:GetCategoryFilter(bag.kind, category) end,
+      func = function()
+        context:Hide()
+        --database:SetCategoryFilter(bag.kind, category, not database:GetCategoryFilter(bag.kind, category))
+        bag:Wipe()
+        bag:Refresh()
+      end
+    })
+  end
+  --TODO(lobato): Iterate custom categories, add them here.
+  table.insert(menuList[2].menuList, {
+    text = L:G("Edit Custom Categories..."),
+    notCheckable = true,
+    hasArrow = false,
+  })
   table.insert(menuList, {
     text = L:G("Compaction"),
     notCheckable = true,

--- a/frames/context.lua
+++ b/frames/context.lua
@@ -154,10 +154,10 @@ function context:CreateContextMenu(bag)
       text = category,
       tooltipTitle = category,
       tooltipText = L:G("If enabled, will categorize items by ") .. category .. ".",
-      checked = function() return database:GetCategoryFilter(bag.kind, category) end,
+      checked = function() return categories:IsCategoryEnabled(category) end,
       func = function()
         context:Hide()
-        --database:SetCategoryFilter(bag.kind, category, not database:GetCategoryFilter(bag.kind, category))
+        categories:ToggleCategory(category)
         bag:Wipe()
         bag:Refresh()
       end

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -259,6 +259,11 @@ function itemProto:IsNewItem()
   return self.data.itemInfo.isNewItem
 end
 
+---@param alpha number
+function itemProto:SetAlpha(alpha)
+  self.frame:SetAlpha(alpha)
+end
+
 function itemProto:Release()
   itemFrame._pool:Release(self)
 end
@@ -269,6 +274,7 @@ function itemProto:ClearItem()
   self.kind = nil
   self.frame:ClearAllPoints()
   self.frame:SetParent(nil)
+  self.frame:SetAlpha(1)
   self.frame:Hide()
   self.button:SetHasItem(false)
   self.button:SetItemButtonTexture(0)

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -18,6 +18,9 @@ local views = addon:GetModule('Views')
 ---@class Sort: AceModule
 local sort = addon:GetModule('Sort')
 
+---@type Item[]
+local toRelease = {}
+
 ---@param bag Bag
 ---@param dirtyItems ItemData[]
 function views:GridView(bag, dirtyItems)
@@ -136,7 +139,7 @@ function views:GridView(bag, dirtyItems)
           section:Release()
         end
       end
-      oldFrame:Release()
+      table.insert(toRelease, oldFrame)
     end
   end
 
@@ -149,11 +152,18 @@ function views:GridView(bag, dirtyItems)
   bag.recentItems:SetMaxCellWidth(sizeInfo.itemsPerRow)
   -- Loop through each section and draw it's size.
   if bag.currentItemCount <= itemCount or bag.kind ~= const.BAG_KIND.BACKPACK then
+    for _, oldFrame in pairs(toRelease) do
+      oldFrame:Release()
+    end
+    wipe(toRelease)
     for _, section in pairs(bag.sections) do
       section:SetMaxCellWidth(sizeInfo.itemsPerRow)
       section:Draw(bag.kind, database:GetBagView(bag.kind))
     end
   else
+    for _, oldFrame in pairs(toRelease) do
+      oldFrame:SetAlpha(0)
+    end
     bag.drawOnClose = true
   end
   bag.currentItemCount = itemCount


### PR DESCRIPTION
This CL rounds off the custom category data and configuration plan. Custom categories now show up in the UI configuration and can be toggled on and off, however categories are not currently loaded from disk on boot yet, and that will come in a later CL.

This CL also adds a small fix for the new grid view option where items do not shift during the selling or removal of items.