### PR TITLE
Add thousands delimiter to gold in bags

### DIFF
--- a/frames/money.lua
+++ b/frames/money.lua
@@ -21,7 +21,7 @@ local moneyProto = {}
 
 function moneyProto:Update()
   local currentMoney = GetMoney()
-  local gold = floor(currentMoney / 1e4)
+  local gold = BreakUpLargeNumbers(floor(currentMoney / 1e4))
   local silver = floor(currentMoney / 100 % 100)
   local copper = currentMoney % 100
   self.goldButton:SetText(tostring(gold))


### PR DESCRIPTION
I don't know if this is the best way to do this, but Blizzard supplies BreakUpLargeNumbers(), which adds thousands delimiters.
Let me know if there is some way this can be done better.