### PR TITLE
Add thousands/millions separator to currency and money

### DIFF
--- a/frames/currency.lua
+++ b/frames/currency.lua
@@ -113,7 +113,7 @@ function CurrencyFrame:Update()
       item.icon:SetTexture(info.iconFileID)
       item.name:SetText(info.name)
       if item.count and not info.isHeader then
-        item.count:SetText(tostring(info.quantity))
+        item.count:SetText(tostring(BreakUpLargeNumbers(info.quantity)))
       end
       if info.isShowInBackpack then
         item.frame:SetBackdropColor(1, 1, 0, .2)
@@ -138,7 +138,7 @@ function CurrencyFrame:Update()
           end
           self.iconGrid:AddCell(info.name, icon)
           icon.icon:SetTexture(info.iconFileID)
-          icon.count:SetText(tostring(info.quantity))
+          icon.count:SetText(tostring(BreakUpLargeNumbers(info.quantity)))
           icon.frame:SetWidth(icon.count:GetStringWidth() + icon.icon:GetWidth() + 7)
           showCount = showCount + 1
         end

--- a/frames/money.lua
+++ b/frames/money.lua
@@ -24,7 +24,7 @@ function moneyProto:Update()
   local gold = floor(currentMoney / 1e4)
   local silver = floor(currentMoney / 100 % 100)
   local copper = currentMoney % 100
-  self.goldButton:SetText(tostring(gold))
+  self.goldButton:SetText(tostring(BreakUpLargeNumbers(gold)))
   self.silverButton:SetText(tostring(silver))
   self.copperButton:SetText(tostring(copper))
   self.copperButton:SetWidth(self.copperButton:GetTextWidth() + 13)


### PR DESCRIPTION
This just uses Blizzard's built in BreakUpLargeNumbers() for Locale specific thousands and millions separators.