### PR TITLE
added new config option to enable coloring item levels relative to ch…

### DIFF
--- a/config/bags.lua
+++ b/config/bags.lua
@@ -200,6 +200,20 @@ function config:GetBagOptions(kind)
               config:GetBag(kind):Refresh()
             end,
           },
+          dynamicColor = { -- New sub-option for dynamic color selection based on item level
+            type = "toggle",
+            name = L:G("Dynamic colors"),
+            desc = L:G("Dynamically select the item level text color based on how the item's level compares to your average item level.\n\nSame or higher: Orange\n1-10 lower: Purple\n11-15 lower: Blue\n16-20 lower: Green\n21+ lower: Yellow"),
+            order = 3,
+            get = function()
+              return DB:GetItemLevelOptions(kind).dynamicColor
+            end,
+            set = function(_, value)
+              DB:SetItemLevelDynamicColorEnabled(kind, value)
+              config:GetBag(kind):Wipe()
+              config:GetBag(kind):Refresh()
+            end,
+          },
         }
       },
 

--- a/core/constants.lua
+++ b/core/constants.lua
@@ -290,11 +290,13 @@ const.DATABASE_DEFAULTS = {
     itemLevel = {
       [const.BAG_KIND.BACKPACK] = {
         enabled = true,
-        color = true
+        color = true,
+        dynamicColor = false
       },
       [const.BAG_KIND.BANK] = {
         enabled = true,
-        color = true
+        color = true,
+        dynamicColor = false
       }
     },
     positions = {

--- a/core/database.lua
+++ b/core/database.lua
@@ -125,6 +125,16 @@ function DB:SetItemLevelColorEnabled(kind, enabled)
   DB.data.profile.itemLevel[kind].color = enabled
 end
 
+function DB:SetItemLevelDynamicColorEnabled(kind, enabled)
+  if DB.data.profile.itemLevel[kind] then
+    DB.data.profile.itemLevel[kind].dynamicColor = enabled
+  end
+end
+
+function DB:GetItemLevelDynamicColorEnabled(kind)
+  return DB.data.profile.itemLevel[kind] and DB.data.profile.itemLevel[kind].dynamicColor or false
+end
+
 function DB:GetFirstTimeMenu()
   return DB.data.profile.firstTimeMenu
 end

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -234,7 +234,13 @@ function itemFrame.itemProto:SetItem(data)
     data.itemInfo.classID == Enum.ItemClass.Gem) then
       self.ilvlText:SetText(tostring(data.itemInfo.currentItemLevel) or "")
       if ilvlOpts.color then
-        local r, g, b = color:GetItemLevelColor(data.itemInfo.currentItemLevel)
+        if ilvlOpts.dynamicColor then
+          -- Use dynamic color based on the player's average item level
+          r, g, b = color:GetItemLevelDynamicColor(data.itemInfo.currentItemLevel)
+        else
+          -- Use static color based on item quality
+          r, g, b = color:GetItemLevelColor(data.itemInfo.currentItemLevel)
+        end
         self.ilvlText:SetTextColor(r, g, b, 1)
       else
         self.ilvlText:SetTextColor(1, 1, 1, 1)

--- a/util/color.lua
+++ b/util/color.lua
@@ -14,6 +14,48 @@ local colorTable = {
   [489] = {1, 0.5, 0}
 }
 
+-- Color criteria based on the item level relative to the player's average item level
+local colorCriteria = {
+  orange = {1, 0.5, 0},      -- Above or equal to average item level
+  purple = {0.63, 0.21, 0.93}, -- 5 or less lower than average item level
+  blue = {0, 0.55, 0.87},    -- 6-10 lower than average item level
+  green = {0, 1, 0},         -- 10-20 lower than average item level
+  yellow = {1, 1, 0}         -- More than 20 lower than average item level
+}
+
+-- Function to determine the average item level of the player using the WoW API
+local function getAverageItemLevel()
+  local averageItemLevel, equippedItemLevel = GetAverageItemLevel()
+  return averageItemLevel -- Returns the average item level of all equipped items
+end
+
+-- Function to determine color based on the item level relative to average item level
+---@param itemLevel number
+---@return table<number, number, number>
+function color:GetItemLevelRelativeColor(itemLevel)
+  local averageItemLevel = getAverageItemLevel()
+  local difference = itemLevel - averageItemLevel
+  
+  if difference >= 0 then
+    return colorCriteria.orange
+  elseif difference >= -10 then
+    return colorCriteria.purple
+  elseif difference >= -15 then
+    return colorCriteria.blue
+  elseif difference >= -20 then
+    return colorCriteria.green
+  else
+    return colorCriteria.yellow
+  end
+end
+
+-- Function to use the determined color for an item level
+---@param itemLevel number
+---@return number, number, number
+function color:GetItemLevelDynamicColor(itemLevel)
+  return unpack(color:GetItemLevelRelativeColor(itemLevel))
+end
+
 ---@param colors table<number, table<number, number, number>>
 ---@param number number
 ---@return table<number, number, number>


### PR DESCRIPTION
This PR is to address [issue 168](https://github.com/Cidan/BetterBags/issues/168).

This PR adds a new option to both bag and bank configuration to enable "Dynamic color" for item levels based on the item's ilvl relative to the character's average item level. 

When enabled, the following logic is used to determine the item's color. 
- item level is above or equal to average item level = orange
- item level is 10 or less lower than average item level = purple
- item level is 1-15 lower than average item level = blue
- item is 16-20 lower than average item level = green
- item is more than 20 lower than average item level = yellow

The ranges and colors are somewhat arbitrary, but are intended to provide "at a glace" usefulness of gear in bags and bank. For example, I generally would not equip gear that is not purple or orange, except in specialized situations (e.g. timewalking).

This functionality could be extended to allow user's to configure item level ranges and colors in the future.

Note that this PR only addresses retail. This implementation was tested in retail 10.2.5 (today, on February 20, 2024). Classic configurations were not created or tested, but it should be trivial to add them by simply modifying the corresponding bags.lua in the same way this bags.lua was modified.