### PR TITLE
Disable conflicting tutorials 

### DIFF
--- a/core/init.lua
+++ b/core/init.lua
@@ -68,7 +68,6 @@ function addon:OnInitialize()
   -- Disable the bag tutorial screens, as Better Bags does not match
   -- the base UI/UX these screens refer to.
   if addon.isRetail then
-		C_CVar.SetCVarBitfield("closedInfoFrames", LE_FRAME_TUTORIAL_EQUIP_REAGENT_BAG --[[@as number]], true)
 		C_CVar.SetCVar("professionToolSlotsExampleShown", 1)
 		C_CVar.SetCVar("professionAccessorySlotsExampleShown", 1)
 	end
@@ -160,4 +159,15 @@ function addon:OnEnable()
   end)
 
   events:RegisterMessage('bags/OpenClose', addon.OnUpdate)
+
+  --This tutorial bitfield change does not persist when set in OnInitialize()
+  if addon.isRetail then
+  -- Disable the mount equipment tutorial as it triggers a taint error from micromenu flashing.
+  -- BetterBags blamed because of ContainerFrameItemButtonTemplate hooking by Tutorials
+  -- https://github.com/Stanzilla/WoWUIBugs/issues/434
+  C_CVar.SetCVarBitfield("closedInfoFrames", LE_FRAME_TUTORIAL_MOUNT_EQUIPMENT_SLOT_FRAME --[[@as number]], true)
+  -- Disable the reagent bag tutorial, as Better Bags does not match
+  -- the base UI/UX these screens refer to.
+  C_CVar.SetCVarBitfield("closedInfoFrames", LE_FRAME_TUTORIAL_EQUIP_REAGENT_BAG --[[@as number]], true)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/Cidan/BetterBags/issues/76
and Adibags issue 952

As mentioned in discord, the Encounter Journal taint is triggered by OnEnter despite the OnOpen reference when the mount equipment tutorial is not cleared.

Running taintlog 2 with only Better Bags loaded:
2/20 03:21:21.905 Interface/SharedXML/TableUtil.lua:88 tDeleteItem() <-- internal Blizzard error
2/20 03:21:21.905 An action was blocked because of taint from BetterBags - OnOpen()
2/20 03:21:21.905 Interface/AddOns/Blizzard_EncounterJournal/Blizzard_EncounterJournal.lua:586

I also moved the reagent bag tutorial as the value successfully sets, but is not persistent when called in OnInitialize and Better Bags inherited the Adibags issue.