### PR TITLE
Item bag slots count display

### DIFF
--- a/config/bags.lua
+++ b/config/bags.lua
@@ -225,6 +225,19 @@ function config:GetBagOptions(kind)
               events:SendMessage('bags/FullRefreshAll')
             end,
           },
+          showBagSlotsUsed = {
+            type = "toggle",
+            name = L:G("Show Bag Slots Used"),
+            desc = L:G("Shows the count of bag slots occupied by a merged unstackable."),
+            order = 5,
+            get = function()
+              return DB:GetStackingOptions(kind).showBagSlotsUsed
+            end,
+            set = function(_, value)
+              DB:SetShowBagSlotsUsed(kind, value)
+              events:SendMessage('bags/FullRefreshAll')
+            end,
+          },
         }
       },
       itemLevel = {

--- a/config/classic/bags.lua
+++ b/config/classic/bags.lua
@@ -223,6 +223,19 @@ function config:GetBagOptions(kind)
               events:SendMessage('bags/FullRefreshAll')
             end,
           },
+          showBagSlotsUsed = {
+            type = "toggle",
+            name = L:G("Show Bag Slots Used"),
+            desc = L:G("Shows the count of bag slots occupied by a merged unstackable."),
+            order = 5,
+            get = function()
+              return DB:GetStackingOptions(kind).showBagSlotsUsed
+            end,
+            set = function(_, value)
+              DB:SetShowBagSlotsUsed(kind, value)
+              events:SendMessage('bags/FullRefreshAll')
+            end,
+          },
         }
       },
       itemLevel = {

--- a/core/constants.lua
+++ b/core/constants.lua
@@ -312,12 +312,14 @@ const.DATABASE_DEFAULTS = {
         mergeUnstackable = true,
         unmergeAtShop = true,
         dontMergePartial = false,
+        showBagSlotsUsed = false,
       },
       [const.BAG_KIND.BANK]  = {
         mergeStacks = true,
         mergeUnstackable = true,
         unmergeAtShop = true,
         dontMergePartial = false,
+        showBagSlotsUsed = false,
       }
     },
     itemLevel = {

--- a/core/database.lua
+++ b/core/database.lua
@@ -324,6 +324,10 @@ function DB:SetDontMergePartial(kind, value)
   DB.data.profile.stacking[kind].dontMergePartial = value
 end
 
+function DB:SetShowBagSlotsUsed(kind, value)
+  DB.data.profile.stacking[kind].showBagSlotsUsed = value
+end
+
 function DB:GetShowKeybindWarning()
   return DB.data.profile.showKeybindWarning
 end

--- a/data/items.lua
+++ b/data/items.lua
@@ -67,7 +67,9 @@ local debug = addon:GetModule('Debug')
 ---@field isItemEmpty boolean
 ---@field kind BagKind
 ---@field newItemTime number
----@field stacks number
+---@field stacks number Count of _additional_ bag slots represented by a view slot
+-- e.g. three unstackable items in a merge-unstackable view will have a single view slot
+-- with ItemData.stacks = 2
 ---@field stackedOn string
 ---@field stackedCount number
 ---@field itemLinkInfo ItemLinkInfo

--- a/frames/classic/item.lua
+++ b/frames/classic/item.lua
@@ -181,6 +181,7 @@ function itemFrame.itemProto:SetFreeSlots(bagid, slotid, count, name)
   self.button.BattlepayItemTexture:SetShown(false)
   self.button.NewItemTexture:Hide()
   self.ilvlText:SetText("")
+  self.stacksCountText:Hide()
   self.LockTexture:Hide()
   self.button.UpgradeIcon:SetShown(false)
 
@@ -220,6 +221,7 @@ function itemFrame.itemProto:ClearItem()
   self.button.minDisplayCount = 1
   self.button:Enable()
   self.ilvlText:SetText("")
+  self.stacksCountText:SetText("")
   self.LockTexture:Hide()
   self:SetSize(37, 37)
   self.button.UpgradeIcon:SetShown(false)
@@ -294,8 +296,12 @@ function itemFrame:_DoCreate()
   button:SetScript("OnEnter", function() i:UpdateTooltip() i:OnEnter() end)
   local ilvlText = button:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
   ilvlText:SetPoint("BOTTOMLEFT", 2, 2)
+  local stacksCountText = button:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+  stacksCountText:SetPoint("TOPRIGHT", -4.8, -2)
+  stacksCountText:SetTextColor(0.8, 0.8, 0.8, 1)
 
   i.ilvlText = ilvlText
+  i.stacksCountText = stacksCountText
 
   return i
 end

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -270,9 +270,10 @@ function itemFrame.itemProto:DrawItemLevel()
 end
 
 function itemFrame.itemProto:UpdateCount()
+  local stackingOptions = database:GetStackingOptions(self.kind)
   if self.data == nil or self.data.isItemEmpty then return end
   local count = self.data.stackedCount or self.data.itemInfo.currentItemCount
-  if self.data.stacks > 0 then
+  if self.data.stacks > 0 and stackingOptions.showBagSlotsUsed then
     -- since ItemData stacks is effectively _additional_ stacks to the base one, take its value + 1
     self.stacksCountText:SetText(tostring(self.data.stacks + 1))
     self.stacksCountText:Show()

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -53,6 +53,7 @@ local debug = addon:GetModule('Debug')
 ---@field kind BagKind
 ---@field masqueGroup string
 ---@field ilvlText FontString
+---@field stacksCountText FontString for tracking the bag slots represented by a view slot
 ---@field IconTexture Texture
 ---@field Count FontString
 ---@field Stock FontString
@@ -209,6 +210,7 @@ function itemFrame.itemProto:Lock()
   SetItemButtonDesaturated(self.button, self.data.itemInfo.isLocked)
   self.LockTexture:Show()
   self.ilvlText:Hide()
+  self.stacksCountText:Hide()
   database:SetItemLock(self.data.itemInfo.itemGUID, true)
 end
 
@@ -270,6 +272,13 @@ end
 function itemFrame.itemProto:UpdateCount()
   if self.data == nil or self.data.isItemEmpty then return end
   local count = self.data.stackedCount or self.data.itemInfo.currentItemCount
+  if self.data.stacks > 0 then
+    -- since ItemData stacks is effectively _additional_ stacks to the base one, take its value + 1
+    self.stacksCountText:SetText(tostring(self.data.stacks + 1))
+    self.stacksCountText:Show()
+  else
+    self.stacksCountText:Hide()
+  end
   SetItemButtonCount(self.button, count)
 end
 
@@ -438,6 +447,8 @@ function itemFrame.itemProto:SetFreeSlots(bagid, slotid, count, name)
   SetItemButtonDesaturated(self.button, false)
   self.ilvlText:SetText("")
   self.ilvlText:Hide()
+  self.stacksCountText:SetText("")
+  self.stacksCountText:Hide()
   self.LockTexture:Hide()
   self.button.UpgradeIcon:SetShown(false)
 
@@ -509,6 +520,8 @@ function itemFrame.itemProto:ClearItem()
   self.button:Enable()
   self.ilvlText:SetText("")
   self.ilvlText:Hide()
+  self.stacksCountText:SetText("")
+  self.stacksCountText:Hide()
   self.LockTexture:Hide()
   self:ResetSize()
   self.data = nil
@@ -605,6 +618,11 @@ function itemFrame:_DoCreate()
   local ilvlText = button:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
   ilvlText:SetPoint("BOTTOMLEFT", 2, 2)
   i.ilvlText = ilvlText
+  
+  local stacksCountText = button:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+  stacksCountText:SetPoint("TOPRIGHT", -4.8, -2)
+  stacksCountText:SetTextColor(0.8, 0.8, 0.8, 1)
+  i.stacksCountText = stacksCountText
 
   i.stacks = {}
   i.stackCount = 1


### PR DESCRIPTION
# "Show bag slots used" feature

This feature, when enabled, paints in the top right corner of a merged unstackable the count of bag slots underlying it.

## Example

Example with an item that stacks to 10:
![image](https://github.com/Cidan/BetterBags/assets/7608707/21929752-0fab-40bc-87b5-429615719017)
this bag view becomes
![image](https://github.com/Cidan/BetterBags/assets/7608707/4536ccea-f7ad-44a3-a63b-b7f7d610c770)
with "merge unstackable" enabled, then
![image](https://github.com/Cidan/BetterBags/assets/7608707/50470f34-a568-4318-910c-352147fbdc67)
with "don't merge partial" enabled.

## Feature toggle

The feature toggle is grouped with the rest of the "Stacking" features (separately between backpack and bank).
What it looks like in the backpack options:
![image](https://github.com/Cidan/BetterBags/assets/7608707/4d7cc031-770e-45eb-b857-024e675765f6)

## Tests

I've checked that this feature interacts correctly with all other stacking features, in both backpack and bank, in both classic era (SoD) and retail.