### PR TITLE
Disable replacement of the bag bar when BT4 is in control of it

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -85,7 +85,7 @@ function config:GetGeneralOptions()
         width = "full",
         order = 2,
         name = L:G("Show Blizzard Bag Button"),
-                desc = L:G("Show or hide the default Blizzard bag button."),
+        desc = L:G("Show or hide the default Blizzard bag button."),
         disabled = function()
           return select(4, C_AddOns.GetAddOnInfo('Bartender4'))
         end,
@@ -99,7 +99,7 @@ function config:GetGeneralOptions()
           end
           DB:SetShowBagButton(value)
         end,
-            },
+      },
       showBagButtonDisabled = {
         type = "description",
         name = L:G("|cffThis option is disabled because Bartender4 is installed."),

--- a/config/config.lua
+++ b/config/config.lua
@@ -85,10 +85,13 @@ function config:GetGeneralOptions()
         width = "full",
         order = 2,
         name = L:G("Show Blizzard Bag Button"),
-        desc = L:G("Show or hide the default Blizzard bag button."),
+                desc = L:G("Show or hide the default Blizzard bag button."),
+        disabled = function()
+          return select(4, C_AddOns.GetAddOnInfo('Bartender4'))
+        end,
         get = DB.GetShowBagButton,
         set = function(_, value)
-          local sneakyFrame = _G["BetterBagsSneakyFrame"] ---@type Frame	
+          local sneakyFrame = _G["BetterBagsSneakyFrame"] ---@type Frame
           if value then
             BagsBar:SetParent(UIParent)
           else
@@ -96,6 +99,14 @@ function config:GetGeneralOptions()
           end
           DB:SetShowBagButton(value)
         end,
+            },
+      showBagButtonDisabled = {
+        type = "description",
+        name = L:G("|cffThis option is disabled because Bartender4 is installed."),
+        hidden = function()
+          return not select(4, C_AddOns.GetAddOnInfo('Bartender4'))
+        end,
+        order = 2.5,
       },
       newItemTime = {
         type = "range",

--- a/core/init.lua
+++ b/core/init.lua
@@ -125,7 +125,7 @@ function addon:OnInitialize()
   end
 
   for _, button in pairs(addon._buttons) do
-    button:HookScript("OnClick",
+    button:SetScript("OnClick",
     function()
       addon:ToggleAllBags()
     end)
@@ -156,23 +156,24 @@ function addon:HideBlizzardBags()
     _G["ContainerFrame"..i]:SetParent(sneakyFrame)
   end
 
-  MainMenuBarBackpackButton:SetScript("OnClick", function()
-    self:ToggleAllBags()
-  end)
 
-  BagBarExpandToggle:SetParent(sneakyFrame)
-  for i = 0, 3 do
-    local bagButton = _G["CharacterBag"..i.."Slot"] --[[@as Button]]
-    bagButton:SetParent(sneakyFrame)
-  end
-  for i = 0, 0 do
-    local bagButton = _G["CharacterReagentBag"..i.."Slot"] --[[@as Button]]
-    bagButton:SetParent(sneakyFrame)
-  end
-
-  if not database:GetShowBagButton() then
-    BagsBar:SetParent(sneakyFrame)
-  end
+	if not select(4, C_AddOns.GetAddOnInfo("Bartender4")) then
+		MainMenuBarBackpackButton:SetScript("OnClick", function()
+			self:ToggleAllBags()
+		end)
+		BagBarExpandToggle:SetParent(sneakyFrame)
+		for i = 0, 3 do
+			local bagButton = _G["CharacterBag"..i.."Slot"] --[[@as Button]]
+			bagButton:SetParent(sneakyFrame)
+		end
+		for i = 0, 0 do
+			local bagButton = _G["CharacterReagentBag"..i.."Slot"] --[[@as Button]]
+			bagButton:SetParent(sneakyFrame)
+		end
+		if not database:GetShowBagButton() then
+			BagsBar:SetParent(sneakyFrame)
+		end
+	end
 
   BankFrame:SetParent(sneakyFrame)
   BankFrame:SetScript("OnHide", nil)


### PR DESCRIPTION
I tested clicking each bag button, bag key bind, and bank access. I have not been able to get the Blizzard Bag UI to open with this in place. 

The current replacement process destroys the existing buttons and Bartender4 controls the visibility and placement of them when it is installed, this leads to the placement being way off. 

The current process leads to the button being off before:
![image](https://github.com/Cidan/BetterBags/assets/704321/645df576-f351-4abd-a3a2-4241b91539d2)

after:
![image](https://github.com/Cidan/BetterBags/assets/704321/b330d769-56cb-49dd-bf3b-dda0e40991dc)

I added a message in the options, and disabled the "Show Blizzard Bag Button" option since with this that call is never made as BT4 handles that.