### PR TITLE
Improve "Recent Items" UX via Fine-Grain Config

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -104,7 +104,8 @@ function config:GetGeneralOptions()
         desc = L:G("The time, in minutes, to consider an item a new item."),
         min = 0,
         max = 240,
-        step = 5,
+        step = 1,
+        bigStep = 5,
         get = function()
           return DB:GetData().profile.newItemTime / 60
         end,

--- a/config/era/config.lua
+++ b/config/era/config.lua
@@ -48,7 +48,8 @@ function config:GetGeneralOptions()
         desc = L:G("The time, in minutes, to consider an item a new item."),
         min = 0,
         max = 240,
-        step = 5,
+        step = 1,
+        bigStep = 5,
         get = function()
           return DB:GetData().profile.newItemTime / 60
         end,


### PR DESCRIPTION
## Use Case
When using the addon, I encountered a use-case where I only wanted to see *very* recent items. I wanted to set the time to 1 minute, but found the options would not let me do so.

Since `step` is the only defined AceConfig Option in the `newItemTime`  arg, the user may only increment the minutes in steps of 5.
However, by using both `step` and `bigStep`, the user may either type a specific quantity desired, or use the slider to step in increments in 5 minutes. I believe the intention behind the 5 minute default step is for a nice slider experience, and this pull request seeks to maintain that desire.

## Pre-Change
Prior to this PR, the user is denied the ability to set a specific time, as the `step` argument mandates that it adheres to 5 minute steps.
![prechange](https://github.com/user-attachments/assets/e69df5e0-71e7-4b68-a95c-ac835090c194)

## Post-Change
After this PR, the user is allowed to either set a specific time, or use the slider to select a quantity in increments of 5 minutes.
![postchange](https://github.com/user-attachments/assets/d7ed1876-37a5-463d-8f05-a77678bf5d13)

Apologies for the poor GIF quality.
Feedback or insight into the desired state appreciated!