### PR TITLE
Move section - Take into account current tab at bank

### DIFF
--- a/core/constants.lua
+++ b/core/constants.lua
@@ -38,13 +38,15 @@ const.BANK_TAB = {
   ACCOUNT_BANK_5 = Enum.BagIndex.AccountBankTab_5,
 }
 
----@enum MovementFlow
+---@enum MovementFlowType
 const.MOVEMENT_FLOW = {
   UNDEFINED = -1,
   BANK = 0,
-  SENDMAIL = 1,
-  TRADE = 2,
-  NPCSHOP = 3
+  REAGENT = 1,
+  WARBANK = 2,
+  SENDMAIL = 3,
+  TRADE = 4,
+  NPCSHOP = 5
 }
 
 -- BANK_BAGS contains all the bags that are part of the bank, including

--- a/frames/section.lua
+++ b/frames/section.lua
@@ -37,7 +37,7 @@ local db = addon:GetModule('Database')
 ---@class Items: AceModule
 local items = addon:GetModule('Items')
 
----@class movementFlow: AceModule
+---@class MovementFlow: AceModule
 local movementFlow = addon:GetModule('MovementFlow')
 
 -------
@@ -286,6 +286,11 @@ function sectionFrame:OnTitleRightClick(section)
     list = newlist
   end
 
+  local containerType = Enum.BankType.Character
+  if flow == const.MOVEMENT_FLOW.WARBANK then
+    containerType = Enum.BankType.Account
+  end
+
   for _, item in pairs(list) do
     -- safecheking: does the bag/slot still hold 'this' item?
     local itemId = C_Container.GetContainerItemID(item.bagid, item.slotid)
@@ -300,7 +305,7 @@ function sectionFrame:OnTitleRightClick(section)
       return
     end
     -- if everything seems ok, move the item
-    C_Container.UseContainerItem(item.bagid, item.slotid)
+    C_Container.UseContainerItem(item.bagid, item.slotid, nil, containerType, flow == const.MOVEMENT_FLOW.REAGENT)
   end
 end
 

--- a/util/movementflow.lua
+++ b/util/movementflow.lua
@@ -6,7 +6,7 @@ local addon = LibStub('AceAddon-3.0'):GetAddon(addonName)
 ---@class Constants: AceModule
 local const = addon:GetModule('Constants')
 
----@class movementFlow: AceModule
+---@class MovementFlow: AceModule
 local movementFlow = addon:NewModule('MovementFlow')
 
 ---@return boolean
@@ -27,8 +27,10 @@ function movementFlow:AtNPCShopWindow()
   return frame ~= nil and frame:IsVisible()
 end
 
----@return MovementFlow
+---@return MovementFlowType
 function movementFlow:GetMovementFlow()
+  if addon.atBank and addon.Bags.Bank.bankTab >= const.BANK_TAB.ACCOUNT_BANK_1 then return const.MOVEMENT_FLOW.WARBANK end
+  if addon.atBank and addon.Bags.Bank.bankTab == const.BANK_TAB.REAGENT then return const.MOVEMENT_FLOW.REAGENT end
   if addon.atBank then return const.MOVEMENT_FLOW.BANK end
   if movementFlow:AtSendMail() then return const.MOVEMENT_FLOW.SENDMAIL end
   if movementFlow:AtTradeWindow() then return const.MOVEMENT_FLOW.TRADE end


### PR DESCRIPTION
When you right click a section at bank, current implementation doesn't take into account the tab selected at the bank (regular bank, reagent or warbank) and send everything to the regular bank. That pr fixes it.