### PR TITLE
Update README.md for Anchor support and BindType searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 BetterBags is a bag replacement addon for World of Warcraft, inspired by AdiBags.  
 It has a fresh, clean look, updated to the 2024 World of Warcraft art style.
 
-It currently does not include all the features of AdiBags, but will slowly incorporate more and more changes over time.
+It currently includes most of the features of AdiBags and is being worked on daily.  
+One of the last major features currently missing is user selectable themes.  
+If you have any feedback, please let us know in the [Discord](https://discord.gg/a6DQuK8hV7).
 
 BetterBags currently supports the following versions of World of Warcraft:  
 Retail (including WoW: Remix and The War Within Pre-Patch)  
@@ -60,10 +62,13 @@ The War Within Beta
 # Summary
 - Items are organized into categories and displayed in a Section Grid.
 - Support for bags, bank, reagent bank, and Warband bank.
+- The bag and bank can be anchored to a location and grow in specified directions.
+- Dynamic number of columns. (TODO)
 - Customizable categories that hold items with multiple sorting options that can be pinned and toggled.
 - Search based categories where the items within the category are defined by a search function.
 - Items within categories have multiple sorting and stacking options (stack all, stack non-stackable, don't stack different transmogs).
 - Powerful recent items support with customizable duration (mark all new items as recent, flash all recent items).
+- Right-click category header to move or vendor all items currently in the category.
 - Comprehensive Search that allows you to find an item most properties of an item (`Type`, `Subtype`, `iLvl`, and many more).
 - Multiple built-in themes with plugin support for the creation of more themes.
 - Robust plugin system allows for custom categories, configurations for user fine-tuning and even localization.
@@ -99,6 +104,16 @@ This temporary view allows you to see your bags and the items within them how th
 <img src="https://i.imgur.com/4YAG0Rm.png" alt="Show Bags in Retail.">
 
 *Show Bags in Retail.*
+</div>
+
+### Bag Anchor
+By default, the bag and bank will grow from the bottom-left corner. Extending both up and right depending on the number of items per row and number of columns.
+A specific anchor can be turned on by left-clicking the bag icon in the top-left corner of the bag and bank. It will allow you to drag the anchor to a specific pixel and grow the bag from whichever corner the anchor is in. Selecting `Enable` will turn on the anchor. Selecting `Show` will allow you to manipulate the anchor and choose the location.
+
+<div align="center" style="text-align:center">
+<img src="https://i.imgur.com/ZiyLfvF.png" alt="Bag Anchor in Retail.">
+
+*Bag Anchor in Retail.*
 </div>
 
 ### Free Spaces
@@ -206,7 +221,7 @@ To purchase bank bag slots, turn on `Show Bags` and click on any red bag slot.
 
 ### Warbank Tabs
 To purchase Warbank tabs, click on the `Purchase Warbank Tab` button, then click purchase on the Blizzard pop-up.  
-Warbank tabs can be renamed and certain item types can be assigned to them by right-clicking on the tab at the bottom of the bank. This will bring up the Blizzard prompt to make any changes.
+Warbank tabs can be renamed and certain item types can be assigned to them by right-clicking on the tab at the bottom of the bank. This will bring up the Blizzard prompt to make any changes. Depositing items into the Warbank tabs will deposit them using Blizzard's rules for depositting items into the Warbank.
 
 <div align="center" style="text-align:center">
 <img src="https://i.imgur.com/98Hgf2I.png" alt="Editing Warbank Tab in Retail.">  
@@ -238,6 +253,16 @@ These can be further fine-tuned by:
 </div>
 
 To disable recent items, uncheck the `Recent Items` category in the config window and set the `New Item Duration` to 0. After hovering over the item and changing anything in the bags, it will stop flashing.
+
+## Move Categories
+Right-clicking on a category header in your bank or bags will move the entire contents of the category to whatever other window you currently have open.
+Supported windows include bags, all bank tabs, the mailbox, the trade window, and vendor windows.
+
+<div align="center" style="text-align:center">
+<img src="https://i.imgur.com/9ahFi16.gif" alt="Move Category in Retail">
+
+*Move Cateogry in Retail.*
+</div>
 
 ## Search
 BetterBags offers a comprehensive Search option that can be toggled with a keybinding (`BetterBags > Search Bags`).
@@ -406,13 +431,12 @@ BetterBags is constantly getting new features and updates.
 Github hosts both our [Progress Board](https://github.com/users/Cidan/projects/2) and means to [report bugs and request new features](https://github.com/Cidan/BetterBags/issues/new/choose).
 
 The following features are under active development:
-- Moving all items in a category by clicking on the category name.
 - Searching for BoE/BoA/WuE items.
 
 These features are planned for the long term:
-- Bag anchors.
 - Dynamic number of columns.
 - User customizable themes.
+- A new config system using a forms style like the search-based category window.
 - Reagent bag markers for items in the reagent bag.
 - Faster/smoother item updates.
 - And much more!

--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ To disable recent items, uncheck the `Recent Items` category in the config windo
 
 ## Move Categories
 Right-clicking on a category header in your bank or bags will move the entire contents of the category to whatever other window you currently have open.
-Supported windows include bags, all bank tabs, the mailbox, the trade window, and vendor windows.
+Supported windows include bags, all bank tabs, the mailbox, the trade window, and vendor windows. Selling items to vendors by right-clicking the header must be turned on in settings.
 
 <div align="center" style="text-align:center">
-<img src="https://i.imgur.com/9ahFi16.gif" alt="Move Category in Retail">
+<img src="https://i.imgur.com/b8BZTlX.gif" alt="Move Category in Retail">
 
 *Move Category in Retail.*
 </div>
@@ -283,8 +283,7 @@ Search allows you to find items by the following indices (based on the item belo
 - `equipmentLocation` or `slot` (slot = Head) The item slot that the gear is for. Examples include Head, Legs, Main-Hand, and Finger.
 - `expansion` or `exp` (expansion = DF) The expansion that the item is originally from. Shorthands are: Classic, BC, WotLK, Cata, MoP, WoD, Legion, BfA, SL, DF, TWW.
 - `equipmentSet` (None in the example) The equipment set(s) that a piece of gear is part of.
-- `bagName` () The name of the bag that the item is located in.
-- `guid` () The globally unique identifier of the item. This string is unique to the specific instance of an item.
+- `guid` (guid = 'item-60-0-4000000C8EB6C663') The globally unique identifier of the item. This string is unique to the specific instance of an item.
 - `binding` (binding = soulbound) The text description of the binding type of the item. Possible values include nonbinding (items that do not bind), boe (bind on equip), bou (bind on use), quest (a soulbound quest item), soulbound (bound to a specific character), refundable (items that can be sold back to a vendor for a full refund), warbound (bound to a warband), bnet (bound to a battle.net account), or wue (warbound until equipped).
 
 ### Numbers

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ The War Within Beta
 - Items are organized into categories and displayed in a Section Grid.
 - Support for bags, bank, reagent bank, and Warband bank.
 - The bag and bank can be anchored to a location and grow in specified directions.
-- Dynamic number of columns. (TODO)
 - Customizable categories that hold items with multiple sorting options that can be pinned and toggled.
 - Search based categories where the items within the category are defined by a search function.
 - Items within categories have multiple sorting and stacking options (stack all, stack non-stackable, don't stack different transmogs).
@@ -261,7 +260,7 @@ Supported windows include bags, all bank tabs, the mailbox, the trade window, an
 <div align="center" style="text-align:center">
 <img src="https://i.imgur.com/9ahFi16.gif" alt="Move Category in Retail">
 
-*Move Cateogry in Retail.*
+*Move Category in Retail.*
 </div>
 
 ## Search
@@ -279,25 +278,30 @@ Search allows you to find items by the following indices (based on the item belo
 ### Strings
 - `name` (name = Silent Tormentor's Hood) The name of the item; the first line in the tooltip.
 - `type` (type = Armor) The type of the item. Some examples include Armor, Weapon, Consumable, and Reagent.
-- `subtype` (subtype = Leather) The subtype of the item. Some examples include Leather, Potion, Bag, and Bows. See the [Wiki](https://warcraft.wiki.gg/wiki/ItemType) for more information regarding type and subtype.
+- `subtype` (subtype = Leather) The subtype of the item. Some examples include Leather, Potion, Bag, and Bows. See the [Warcraft Wiki](https://warcraft.wiki.gg/wiki/ItemType) for more information regarding type and subtype.
 - `category` (category = Head) The category that the item is sorted into in BetterBags.
 - `equipmentLocation` or `slot` (slot = Head) The item slot that the gear is for. Examples include Head, Legs, Main-Hand, and Finger.
 - `expansion` or `exp` (expansion = DF) The expansion that the item is originally from. Shorthands are: Classic, BC, WotLK, Cata, MoP, WoD, Legion, BfA, SL, DF, TWW.
 - `equipmentSet` (None in the example) The equipment set(s) that a piece of gear is part of.
+- `bagName` () The name of the bag that the item is located in.
+- `guid` () The globally unique identifier of the item. This string is unique to the specific instance of an item.
+- `binding` (binding = soulbound) The text description of the binding type of the item. Possible values include nonbinding (items that do not bind), boe (bind on equip), bou (bind on use), quest (a soulbound quest item), soulbound (bound to a specific character), refundable (items that can be sold back to a vendor for a full refund), warbound (bound to a warband), bnet (bound to a battle.net account), or wue (warbound until equipped).
 
 ### Numbers
 - `level` or `ilvl` (ilvl = 506) The item level of the item. Non-gear items have item levels as well, but they are not shown to the user.
 - `rarity` (rarity = epic or rarity = 4) The rarity of the item. Poor = 0, Common = 1, Uncommon = 2, Rare = 3, Epic = 4, Legendary = 5.
-- `id` (id = 207133) The internal itemID of the item. A number uniquely identifying the item. Specific ItemIDs can be found in the url on the item's WoWHead page.
-- `stackCount` or `count` (stackCount = 1) The number of items in the stack for the item.
+- `id` (id = 207133) The internal itemID of the item. A number uniquely identifying the base item. Specific ItemIDs can be found in the url on the item's WoWHead page.
+- `stackCount` or `count` (stackCount = 1) The number of items in the stack for the item. Currently count only takes into account the stack size of the "base" stack when using virtual stacks. For example, a virtual stack of 20, 20, and 3 to total 43 items will only be matched with either 20 or 3, not both.
 - `class` (class = 4) The numeric representation of itemType.
-- `subclass` (subclass = 2) The numeric representation of itemSubtype. See the [Wiki](https://warcraft.wiki.gg/wiki/ItemType) for more information regarding class and subclass.
+- `subclass` (subclass = 2) The numeric representation of itemSubtype. See the [Warcraft Wiki](https://warcraft.wiki.gg/wiki/ItemType) for more information regarding class and subclass.
 - `bagid` (bagid = 3) The location of the bag containing the item. BagID is 0 for the main backpack, 1-4 for the bags, 5 for a reagent bag (Retail only), -1 for the main bank window, 6-12 for bank bags, -3 for the reagent bank, -2 for the keyring (Classic only), and 13-17 for warbank tabs.
 - `slotid` (slotid = 6) The slot that the item is in, in the bag that contains it. Numbered from 1 to N for each bagID, where N is the size of the container.
+- `bindtype` (bindtype = 1) The binding type of the item returned by GetItemInfo(). 1 = BoP, 2 = BoE, 3 = BoU, 4 = Quest, 7 = BtA, 8 = BtW, 9 = WuE. See the [Warcraft Wiki](https://warcraft.wiki.gg/wiki/Enum.ItemBind) for specifics.
 
 ### Booleans
 - `reagent` (reagent = false) Is the item classified as a reagent?
-- `bound` (bound = true) Is the item bound to the character?
+- `bound` (bound = true) Is the item bound to the character or warband? (From BetterBags internal module)
+- `isbound` (isbound = true) Is the item bound to the character or account? (From Blizzard C_Item)
 - `quest` (quest = false) Is the item for a non-active quest?
 - `activeQuest` (activeQuest = false) Is the item for an active quest?
 
@@ -431,10 +435,9 @@ BetterBags is constantly getting new features and updates.
 Github hosts both our [Progress Board](https://github.com/users/Cidan/projects/2) and means to [report bugs and request new features](https://github.com/Cidan/BetterBags/issues/new/choose).
 
 The following features are under active development:
-- Searching for BoE/BoA/WuE items.
+- Dynamic number of columns.
 
 These features are planned for the long term:
-- Dynamic number of columns.
 - User customizable themes.
 - A new config system using a forms style like the search-based category window.
 - Reagent bag markers for items in the reagent bag.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Search allows you to find items by the following indices (based on the item belo
 - `expansion` or `exp` (expansion = DF) The expansion that the item is originally from. Shorthands are: Classic, BC, WotLK, Cata, MoP, WoD, Legion, BfA, SL, DF, TWW.
 - `equipmentSet` (None in the example) The equipment set(s) that a piece of gear is part of.
 - `guid` (guid = 'item-60-0-4000000C8EB6C663') The globally unique identifier of the item. This string is unique to the specific instance of an item.
-- `binding` (binding = soulbound) The text description of the binding type of the item. Possible values include nonbinding (items that do not bind), boe (bind on equip), bou (bind on use), quest (a soulbound quest item), soulbound (bound to a specific character), refundable (items that can be sold back to a vendor for a full refund), warbound (bound to a warband), bnet (bound to a battle.net account), or wue (warbound until equipped).
+- `binding` (binding = soulbound) The text description of the binding type of the item. Possible values include nonbinding (items that do not bind), boe (bind on equip), bou (bind on use), quest (a soulbound quest item), soulbound (bound to a specific character), refundable (items that can be sold back to a vendor for a full refund), warbound (bound to a warband), bnet (bound to a battle.net account), or wue (warbound until equipped). **Note:** soulbound and warbound are only available on Retail because of API limitations on non-Retail versions.
 
 ### Numbers
 - `level` or `ilvl` (ilvl = 506) The item level of the item. Non-gear items have item levels as well, but they are not shown to the user.
@@ -438,6 +438,7 @@ The following features are under active development:
 
 These features are planned for the long term:
 - User customizable themes.
+- Character specific profiles.
 - A new config system using a forms style like the search-based category window.
 - Reagent bag markers for items in the reagent bag.
 - Faster/smoother item updates.


### PR DESCRIPTION
Include information about click-to-move categories.
Update Warbank information for depositing items into the warbank.
Update planned/under-development features.
Update search section with the newest search features.
Explicitly mention Warcraft.wiki.