### PR TITLE
Feature/updated layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/*
 /libs/**
 /includes/**
 # Bugfix for Cursor editor.

--- a/forms/form.lua
+++ b/forms/form.lua
@@ -113,50 +113,50 @@ function formFrame:AddSubSection(opts)
 end
 
 ---@param opts FormSliderOptions
-function formFrame:AddSlider(opts)
-  self.layout:AddSlider(opts)
+function formFrame:AddSlider(opts, frameName)
+  self.layout:AddSlider(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormInputBoxOptions
-function formFrame:AddInputBox(opts)
-  self.layout:AddInputBox(opts)
+function formFrame:AddInputBox(opts, frameName)
+  self.layout:AddInputBox(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormDropdownOptions
-function formFrame:AddDropdown(opts)
-  self.layout:AddDropdown(opts)
+function formFrame:AddDropdown(opts, frameName)
+  self.layout:AddDropdown(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormTextAreaOptions
-function formFrame:AddTextArea(opts)
-  self.layout:AddTextArea(opts)
+function formFrame:AddTextArea(opts, frameName)
+  self.layout:AddTextArea(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormCheckboxOptions
-function formFrame:AddCheckbox(opts)
-  self.layout:AddCheckbox(opts)
+function formFrame:AddCheckbox(opts, frameName)
+  self.layout:AddCheckbox(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormButtonGroupOptions
-function formFrame:AddButtonGroup(opts)
-  self.layout:AddButtonGroup(opts)
+function formFrame:AddButtonGroup(opts, frameName)
+  self.layout:AddButtonGroup(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormColorOptions
-function formFrame:AddColor(opts)
-  self.layout:AddColor(opts)
+function formFrame:AddColor(opts, frameName)
+  self.layout:AddColor(opts, frameName)
   self:Resize()
 end
 
 ---@param opts FormLabelOptions
-function formFrame:AddLabel(opts)
-  self.layout:AddLabel(opts)
+function formFrame:AddLabel(opts, frameName)
+  self.layout:AddLabel(opts, frameName)
   self:Resize()
 end
 

--- a/forms/layouts/stacked.lua
+++ b/forms/layouts/stacked.lua
@@ -368,14 +368,14 @@ function stackedLayout:AddCheckbox(opts)
   container.checkbox:SetChecked(opts.getValue(context:New('Checkbox_Load')))
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("LEFT", container.checkbox, "RIGHT", 5, 0)
+  container.title:SetPoint("LEFT", container.checkbox, "RIGHT", (opts.left or 0) + 5, (opts.top or 0))
   container.title:SetPoint("RIGHT", container, "RIGHT", 0, 0)
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
   container.description:SetPoint("RIGHT", container, "RIGHT", 0, 0)
 
-  container:SetHeight(container.title:GetLineHeight() + container.description:GetLineHeight() + 25)
+  container:SetHeight(container.title:GetLineHeight() + container.description:GetLineHeight() + (opts.bottom or 25))
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
   self.checkboxes[container] = opts
@@ -389,13 +389,13 @@ function stackedLayout:addDropdownRetail(opts)
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   container.dropdown = CreateFrame("DropdownButton", nil, container, "WowStyle1DropdownTemplate") --[[@as DropdownButton]]
-  container.dropdown:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", 0, -5)
+  container.dropdown:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
   container.dropdown:SetPoint("RIGHT", container, "RIGHT", 0, 0)
 
   ---@type string[]
@@ -429,7 +429,7 @@ function stackedLayout:addDropdownRetail(opts)
     container.title:GetLineHeight() +
     container.description:GetLineHeight() +
     container.dropdown:GetHeight() +
-    25
+    (opts.bottom or 25)
   )
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
@@ -444,13 +444,13 @@ function stackedLayout:addDropdownClassic(opts)
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   container.classicDropdown = CreateFrame("Frame", nil, container, "UIDropDownMenuTemplate") --[[@as Frame]]
-  container.classicDropdown:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", 0, -5)
+  container.classicDropdown:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
   container.classicDropdown:SetPoint("RIGHT", container, "RIGHT", 0, 0)
 
   ---@type string[]
@@ -494,7 +494,7 @@ function stackedLayout:addDropdownClassic(opts)
     container.title:GetLineHeight() +
     container.description:GetLineHeight() +
     container.classicDropdown:GetHeight() +
-    25
+    (opts.bottom or 25)
   )
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
@@ -517,17 +517,17 @@ function stackedLayout:AddSlider(opts)
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   if addon.isRetail then
     container.slider = CreateFrame("Slider", nil, container, "UISliderTemplate") --[[@as Slider]]
   else
     container.slider = CreateFrame("Slider", nil, container, "HorizontalSliderTemplate") --[[@as Slider]]
   end
-  container.slider:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", 0, -5)
+  container.slider:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
   container.slider:SetPoint("RIGHT", container, "RIGHT", 0, 0)
   container.slider:SetOrientation("HORIZONTAL")
   container.slider:SetHeight(20)
@@ -544,7 +544,7 @@ function stackedLayout:AddSlider(opts)
 
   container.input = CreateFrame("EditBox", nil, container, "InputBoxTemplate") --[[@as EditBox]]
   container.input:SetSize(50, 20)
-  container.input:SetPoint("TOP", container.slider, "BOTTOM", 0, -5)
+  container.input:SetPoint("TOP", container.slider, "BOTTOM", (opts.left or 0), (opts.top or -5))
   container.input:SetNumeric(true)
   container.input:SetAutoFocus(false)
   addon.SetScript(container.input, "OnEditFocusLost", function(_)
@@ -567,9 +567,9 @@ function stackedLayout:AddSlider(opts)
     if user then
       local value = tonumber(container.input:GetText())
       if value then
-        if value < opts.min then
+        if tonumber(value) < tonumber(opts.min) then
           value = opts.min
-        elseif value > opts.max then
+        elseif tonumber(value) > tonumber(opts.max) then
           value = opts.max
         end
         container.slider:SetValue(value)
@@ -589,7 +589,7 @@ function stackedLayout:AddSlider(opts)
     container.description:GetLineHeight() +
     container.slider:GetHeight() +
     container.input:GetHeight() +
-    30
+    (opts.bottom or 30)
   )
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
@@ -606,20 +606,29 @@ function stackedLayout:AddButtonGroup(opts)
   for _, buttonData in ipairs(opts.ButtonOptions) do
     local button = CreateFrame("Button", nil, container, "UIPanelButtonTemplate") --[[@as Button]]
     button:SetText(buttonData.title)
-    local w = button:GetFontString():GetStringWidth()
-    button:SetSize(w + 6, 24)
+    button:SetSize(buttonData.width or button:GetFontString():GetStringWidth() + 6, buttonData.height or 24)
     addon.SetScript(button, "OnClick", function(ctx)
       buttonData.onClick(ctx)
     end)
-    if #container.buttons == 0 then
-      button:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+    if buttonData.align ~= nil and buttonData.align == "RIGHT" then
+      if #container.buttons == 0 then
+        button:SetPoint("TOPRIGHT", container, "TOPRIGHT", (buttonData.right or 0), (buttonData.top or 0))
+      elseif container.buttons[#container.buttons].align ~= nil and container.buttons[#container.buttons].align == "RIGHT" then
+        button:SetPoint("TOPRIGHT", container.buttons[#container.buttons], "TOPLEFT", (buttonData.right or 0), (buttonData.top or 0))
+      else
+        button:SetPoint("TOPRIGHT", container, "TOPRIGHT", (buttonData.right or 0), (buttonData.top or 0))
+      end
     else
-      button:SetPoint("TOPLEFT", container.buttons[#container.buttons], "TOPRIGHT", -10, 0)
+      if #container.buttons == 0 then
+        button:SetPoint("TOPLEFT", container, "TOPLEFT", (buttonData.left or 0) + 37, (buttonData.top or 0))
+      else
+        button:SetPoint("TOPLEFT", container.buttons[#container.buttons], "TOPRIGHT", (buttonData.left or 0), (buttonData.top or 0))
+      end
     end
     table.insert(container.buttons, button)
   end
 
-  container:SetHeight(container.buttons[1]:GetHeight() + 30)
+  container:SetHeight(container.buttons[1]:GetHeight() + (opts.bottom or 30))
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
   self.buttonGroups[container] = opts
@@ -632,10 +641,10 @@ function stackedLayout:AddTextArea(opts)
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   local ScrollBox = CreateFrame("Frame", nil, container, "WowScrollBox") --[[@as WowScrollBox]]
   ScrollBox:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", 0, -5)
@@ -698,7 +707,7 @@ function stackedLayout:AddTextArea(opts)
     container.title:GetLineHeight() +
     container.description:GetLineHeight() +
     ScrollBox:GetHeight() +
-    30
+    (opts.bottom or 30)
   )
 
   ScrollUtil.InitScrollBoxWithScrollBar(ScrollBox, ScrollBar, view)
@@ -714,13 +723,13 @@ function stackedLayout:AddInputBox(opts)
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.title:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   container.input = CreateFrame("EditBox", nil, container, "InputBoxTemplate") --[[@as EditBox]]
-  container.input:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", 5, -5)
+  container.input:SetPoint("TOPLEFT", container.description, "BOTTOMLEFT", (opts.left or 0) + 5, (opts.top or -5))
   container.input:SetPoint("RIGHT", container, "RIGHT", -5, 0)
   container.input:SetHeight(20)
   container.input:SetAutoFocus(false)
@@ -743,7 +752,7 @@ function stackedLayout:AddInputBox(opts)
     container.title:GetLineHeight() +
     container.description:GetLineHeight() +
     container.input:GetHeight() +
-    30
+    (opts.bottom or 30)
   )
 
   self.nextFrame = container
@@ -800,17 +809,16 @@ function stackedLayout:AddColor(opts)
     ColorPickerFrame:SetupColorPickerAndShow(options)
   end)
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
-  container.title:SetPoint("LEFT", container.colorPicker, "RIGHT", 5, 0)
+  container.title:SetPoint("LEFT", container.colorPicker, "RIGHT", (opts.left or 0) + 5, 0)
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", 0, -5)
-
+  container.description:SetPoint("TOPLEFT", container.title, "BOTTOMLEFT", (opts.left or 0), (opts.top or -5))
 
   container:SetHeight(
     container.title:GetLineHeight() +
     container.description:GetLineHeight() +
     container.colorPicker:GetHeight() +
-    30
+    (opts.bottom or 30)
   )
 
   self.nextFrame = container
@@ -825,10 +833,10 @@ function stackedLayout:AddLabel(opts)
   self:alignFrame(t, container)
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})
-  container.description:SetPoint("TOPLEFT", container, "TOPLEFT", 37, 0)
+  container.description:SetPoint("TOPLEFT", container, "TOPLEFT", (opts.left or 0) + 37, (opts.top or 0))
   container.description:SetPoint("RIGHT", container, "RIGHT", -5, 0)
 
-  container:SetHeight(container.description:GetLineHeight() + 10)
+  container:SetHeight(container.description:GetLineHeight() + (opts.bottom or 10))
   self.nextFrame = container
   self.height = self.height + container:GetHeight()
 end

--- a/forms/layouts/stacked.lua
+++ b/forms/layouts/stacked.lua
@@ -354,9 +354,9 @@ function stackedLayout:AddSubSection(opts)
 end
 
 ---@param opts FormCheckboxOptions
-function stackedLayout:AddCheckbox(opts)
+function stackedLayout:AddCheckbox(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormCheckbox]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormCheckbox]]
   self:alignFrame(t, container)
 
   container.checkbox = CreateFrame("CheckButton", nil, container, "UICheckButtonTemplate") --[[@as CheckButton]]
@@ -383,9 +383,9 @@ end
 
 ---@private
 ---@param opts FormDropdownOptions
-function stackedLayout:addDropdownRetail(opts)
+function stackedLayout:addDropdownRetail(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormDropdown]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormDropdown]]
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
@@ -438,9 +438,9 @@ end
 
 ---@private
 ---@param opts FormDropdownOptions
-function stackedLayout:addDropdownClassic(opts)
+function stackedLayout:addDropdownClassic(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormDropdown]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormDropdown]]
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
@@ -502,18 +502,18 @@ function stackedLayout:addDropdownClassic(opts)
 end
 
 ---@param opts FormDropdownOptions
-function stackedLayout:AddDropdown(opts)
+function stackedLayout:AddDropdown(opts, frameName)
   if addon.isRetail then
-    self:addDropdownRetail(opts)
+    self:addDropdownRetail(opts, frameName)
     return
   end
-  self:addDropdownClassic(opts)
+  self:addDropdownClassic(opts, frameName)
 end
 
 ---@param opts FormSliderOptions
-function stackedLayout:AddSlider(opts)
+function stackedLayout:AddSlider(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormSlider]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormSlider]]
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
@@ -597,9 +597,9 @@ function stackedLayout:AddSlider(opts)
 end
 
 ---@param opts FormButtonGroupOptions
-function stackedLayout:AddButtonGroup(opts)
+function stackedLayout:AddButtonGroup(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormButtons]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormButtons]]
   self:alignFrame(t, container)
   container.buttons = {}
 
@@ -635,9 +635,9 @@ function stackedLayout:AddButtonGroup(opts)
 end
 
 ---@param opts FormTextAreaOptions
-function stackedLayout:AddTextArea(opts)
+function stackedLayout:AddTextArea(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormTextArea]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormTextArea]]
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
@@ -717,9 +717,9 @@ function stackedLayout:AddTextArea(opts)
 end
 
 ---@param opts FormInputBoxOptions
-function stackedLayout:AddInputBox(opts)
+function stackedLayout:AddInputBox(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormInputBox]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormInputBox]]
   self:alignFrame(t, container)
 
   container.title = self:createTitle(container, opts.title, {0.75, 0.75, 0.75})
@@ -761,9 +761,9 @@ function stackedLayout:AddInputBox(opts)
 end
 
 ---@param opts FormColorOptions
-function stackedLayout:AddColor(opts)
+function stackedLayout:AddColor(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormColor]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormColor]]
   self:alignFrame(t, container)
 
   container.colorPicker = CreateFrame("Frame", nil, container) --[[@as Frame]]
@@ -827,9 +827,9 @@ function stackedLayout:AddColor(opts)
 end
 
 ---@param opts FormLabelOptions
-function stackedLayout:AddLabel(opts)
+function stackedLayout:AddLabel(opts, frameName)
   local t = self.nextFrame
-  local container = CreateFrame("Frame", nil, t) --[[@as FormLabel]]
+  local container = CreateFrame("Frame", frameName or nil, t) --[[@as FormLabel]]
   self:alignFrame(t, container)
 
   container.description = self:createDescription(container, opts.description, {0.75, 0.75, 0.75})


### PR DESCRIPTION
Hi there!

I'm developing addons for BetterBags, and I'm currently fighting with the new option UI.

I added a few options to control the option layout for external plugins, the default values sometimes give an ugly result, adding these options may give us more control to adjust the layout of plugins option section :)

I added the possibility to name the frames, to be able to access them easily (for example I created a button that sets the value of the slider)

I corrected 2 bugs I found while working on my addon:
- the AddButtonGroup had a negative left position for additional buttons that caused them to overlap, set it to 0 by default
- for the slider, when I edited the value with the input I got a type error, so I casted the vars to numbers

Edited .gitignore to add my IDE config folder