### PR TITLE
showing item level on profession items

### DIFF
--- a/frames/item.lua
+++ b/frames/item.lua
@@ -148,7 +148,7 @@ function itemFrame.itemProto:ShowItemLevel()
   local data = items:GetItemDataFromSlotKey(self.slotkey)
   local ilvl = data.itemInfo.currentItemLevel
   self.ilvlText:SetText(tostring(ilvl))
-  if ilvlOpts.color then
+  if ilvlOpts.color and data.itemInfo.classID ~= Enum.ItemClass.Profession then
     local r, g, b = color:GetItemLevelColor(ilvl)
     self.ilvlText:SetTextColor(r, g, b, 1)
   else
@@ -170,8 +170,11 @@ function itemFrame.itemProto:DrawItemLevel()
     return
   end
 
-  if (data.itemInfo.classID ~= Enum.ItemClass.Armor and
-  data.itemInfo.classID ~= Enum.ItemClass.Weapon) then
+  if (
+    data.itemInfo.classID ~= Enum.ItemClass.Armor and
+    data.itemInfo.classID ~= Enum.ItemClass.Weapon and
+    data.itemInfo.classID ~= Enum.ItemClass.Profession
+  ) then
     self.ilvlText:Hide()
     return
   end


### PR DESCRIPTION
Profession items have ilevel that is relevent to their use (altough the color part is not, since the icon border is enough). 

This small change add their itemclass to the list of items that should have the item level displayed if the option for that is enabled. 
