### PR TITLE
Fix for bug #742 

### DIFF
--- a/core/database.lua
+++ b/core/database.lua
@@ -226,9 +226,11 @@ function DB:SaveItemToCategory(itemID, category)
   assert(DB.data.profile.customCategoryFilters[category] ~= nil, "Category does not exist: " .. category)
   DB.data.profile.customCategoryFilters[category].itemList[itemID] = true
   local previousCategory = DB.data.profile.customCategoryIndex[itemID]
-  if previousCategory and previousCategory ~= category then
+  local previousCategoryFilter = DB.data.profile.customCategoryFilters[category]
+  if previousCategory and previousCategoryFilter and previousCategory ~= category then
     DB.data.profile.customCategoryFilters[previousCategory].itemList[itemID] = nil
   end
+  DB.data.profile.customCategoryFilters[category].itemList[itemID] = true
   DB.data.profile.customCategoryIndex[itemID] = category
 end
 


### PR DESCRIPTION
Adding item to Custom Category when Previous Custom Category is deleted cause some lua errors.

This pull request fixes the two problems:
1: not checking for existence of the previous category's filter before calling it
2: not adding the item to the new category's item list
