### PR TITLE
Add the "OnEnterPressed" event to the slider input box

### DIFF
--- a/forms/layouts/stacked.lua
+++ b/forms/layouts/stacked.lua
@@ -565,20 +565,26 @@ function stackedLayout:AddSlider(opts)
     container.input:SetText(tostring(container.slider:GetValue()))
     self:ReloadAllFormElements()
   end)
+  -- Wait for the user to submit the value directly before validating
+  addon.SetScript(container.input, "OnEnterPressed", function(_)
+    local value = tonumber(container.input:GetText())
+    if value then
+      if value < opts.min then
+        value = opts.min
+      elseif value > opts.max then
+        value = opts.max
+      end
+      container.slider:SetValue(value)
+      container.input:SetText(tostring(value))
+    else
+      value = opts.min
+    end
+  end)
   addon.SetScript(container.input, "OnTextChanged", function(_, _, user)
     if user then
-      local value = tonumber(container.input:GetText())
-      if value then
-        if value < opts.min then
-          value = opts.min
-        elseif value > opts.max then
-          value = opts.max
-        end
-        container.slider:SetValue(value)
-        container.input:SetText(tostring(value))
-      else
-        value = opts.min
-      end
+      -- Don't set the value immediately, it makes it impossible to enter in a specific
+      -- value because a temporary value will be outside the min and max most likely
+      return
     else
       container.input:SetText(tostring(container.slider:GetValue()))
     end


### PR DESCRIPTION
This makes it so the user can submit a value rather than the text being validated on every character change.

I'm not sure if `OnEnterPressed` wasn't added for a compatibility issue, but it feels better that it works this way rather than your inputs getting trashed over and over.

Addresses #788.