### PR TITLE
Add a toggle for Bank replacement

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -92,6 +92,21 @@ function config:CreateConfig()
     end
   })
 
+  f:AddCheckbox({
+    title = 'Use Blizzard Bank UI',
+    description = 'If enabled, BetterBags will leave the Blizzard Bank/Warbank frames intact and not replace them. Requires UI reload.',
+    getValue = function(_)
+      return db:GetUseBlizzardBank()
+    end,
+    setValue = function(ctx, value)
+      db:SetUseBlizzardBank(value)
+      -- Changing whether we replace the Blizzard bank requires a UI reload to apply cleanly.
+      question:YesNo('Reload UI', 'Changing the bank UI backend requires reloading the UI. Reload now?', function()
+        ReloadUI()
+      end, function() end)
+    end
+  })
+
   f:AddDropdown({
     title = 'Upgrade Icon Provider',
     description = 'Select the icon provider for item upgrades.',

--- a/core/constants.lua
+++ b/core/constants.lua
@@ -567,6 +567,7 @@ const.DATABASE_DEFAULTS = {
     firstTimeMenu = true,
     enabled = true,
     showBagButton = true,
+    useBlizzardBank = false,
     characterBankTabsEnabled = false,
     debug = false,
     inBagSearch = true,

--- a/core/database.lua
+++ b/core/database.lua
@@ -110,6 +110,16 @@ function DB:GetShowBagButton()
 end
 
 ---@param enabled boolean
+function DB:SetUseBlizzardBank(enabled)
+  DB.data.profile.useBlizzardBank = enabled
+end
+
+---@return boolean
+function DB:GetUseBlizzardBank()
+  return DB.data.profile.useBlizzardBank
+end
+
+---@param enabled boolean
 function DB:SetCharacterBankTabsEnabled(enabled)
   DB.data.profile.characterBankTabsEnabled = enabled
 end


### PR DESCRIPTION
Adds a configuration option to use the default Blizzard Bank UI. The change requires a reload.

https://github.com/Cidan/BetterBags/issues/809