### PR TITLE
Bug - Bag Cell Layout is Inconsistent

### DIFF
--- a/frames/grid.lua
+++ b/frames/grid.lua
@@ -9,6 +9,9 @@ local const = addon:GetModule('Constants')
 ---@class GridFrame: AceModule
 local grid = addon:NewModule('Grid')
 
+---@class Debug: AceModule
+local debug = addon:GetModule('Debug')
+
 ---@class Cell
 ---@field frame Frame
 
@@ -354,7 +357,6 @@ function gridProto:calculateColumns(options)
 
       -- Need to increase splitAt to reduce number of columns, try evenly increasing by the overshot height/2 and try again
       splitAt = splitAt + math.ceil(overshoot / (2 * options.columns))
-      columns = nil
     else
       return columns
     end


### PR DESCRIPTION
There are several issues with how cells are distributed into columns in bags and banks. With extra large groups, it is very easy to see. I'm fixing all the issues that I found related to this.

- When one cell's height is larger than how large the column would be if we simply divide `totalHeight / columnCount`, we can use this height instead. This avoids unnecessary columns.
- First cell in the bag and first cell in each column is ignored when calculating. This would cause uneven columns, especially when said cell is large.
  - Correctly account for width and height.
- Some totals were missing spacing in one loop and not in the other.
  - I made sure the loops calculate width in the same way.
  - If this is a feature, then spacing should be ignored in both loops.
- Conditions ignore spacing.
  - I did not change this as it seems to be a feature.