### PR TITLE
feat(config): add tooltip to category list items in options screen

### DIFF
--- a/config/categorypane.lua
+++ b/config/categorypane.lua
@@ -200,7 +200,7 @@ function categoryPaneProto:initListItem(button, elementData)
         button:SetBackdropColor(0.3, 0.3, 0.3, 0.5)
       end
       GameTooltip:SetOwner(button, "ANCHOR_RIGHT")
-      GameTooltip:SetText(L:G("Shift-click to move this category to the pinned category section"), 1, 1, 1, true)
+      GameTooltip:SetText(L:G("Shift-click to move this category to the pinned category section"), 1, 1, 1, 1, true)
       GameTooltip:Show()
     end)
 


### PR DESCRIPTION
## Summary

- Re-adds the tooltip to category items in the category options list
- When hovering over a category entry, shows a `GameTooltip` with the text: **"Shift-click to move this category to the pinned category section"**
- Tooltip is shown on `OnEnter` and hidden on `OnLeave`
- Header items are unaffected (they have no `OnEnter`/`OnLeave` handlers)

## Test plan

- [ ] Open BetterBags options → Categories tab
- [ ] Hover over any non-header category in the list
- [ ] Verify tooltip appears with text: "Shift-click to move this category to the pinned category section"
- [ ] Move mouse away and verify tooltip disappears
- [ ] Verify shift-click still correctly pins the category
- [ ] Verify header entries do not show a tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)