### PR TITLE
feat: We need to expand our Busted test environment for BetterB...

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -10,7 +10,7 @@ checkout_svn() {
   else
     echo "Checking out SVN repository to $dest"
     svn checkout "$url" "$dest"
-  end
+  fi
 }
 
 clone_git() {
@@ -22,23 +22,23 @@ clone_git() {
   else
     echo "Cloning Git repository to $dest"
     git clone "$url" "$dest"
-  end
+  fi
 }
 
 checkout_svn https://repos.wowace.com/wow/libstub/tags/1.0 ./libs/LibStub
 checkout_svn https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0 ./libs/CallbackHandler-1.0
 checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceAddon-3.0 ./libs/AceAddon-3.0
+checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0 ./libs/AceConfig-3.0
+checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0 ./libs/AceConsole-3.0
 checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceDB-3.0 ./libs/AceDB-3.0
 checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceDBOptions-3.0 ./libs/AceDBOptions-3.0
-checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceHook-3.0 ./libs/AceHook-3.0
-checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceGUI-3.0 ./libs/AceGUI-3.0
-checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0 ./libs/AceConsole-3.0
-checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0 ./libs/AceConfig-3.0
 checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceEvent-3.0 ./libs/AceEvent-3.0
+# checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceGUI-3.0 ./libs/AceGUI-3.0
+checkout_svn https://repos.wowace.com/wow/ace3/trunk/AceHook-3.0 ./libs/AceHook-3.0
 clone_git https://github.com/tekkub/libdatabroker-1-1 ./libs/LibDataBroker-1.1
 clone_git https://github.com/wagoio/WagoAnalyticsShim.git ./libs/WagoAnalytics
 checkout_svn https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0 ./libs/LibSharedMedia-3.0
-checkout_svn https://repos.wowace.com/wow/ace-gui-3-0-shared-media-widgets/trunk/AceGUI-3.0-SharedMediaWidgets ./libs/AceGUI-3.0-SharedMediaWidgets
+# checkout_svn https://repos.wowace.com/wow/ace-gui-3-0-shared-media-widgets/trunk/AceGUI-3.0-SharedMediaWidgets ./libs/AceGUI-3.0-SharedMediaWidgets
 checkout_svn https://repos.curseforge.com/wow/libwindow-1-1/trunk/LibWindow-1.1 ./libs/LibWindow-1.1
 checkout_svn https://repos.wowace.com/wow/libuidropdownmenu/trunk/LibUIDropDownMenu ./libs/LibUIDropDownMenu
 

--- a/spec/basic_spec.lua
+++ b/spec/basic_spec.lua
@@ -1,4 +1,4 @@
-describe("AceAddon-3.0 Test", function()
+describe("Ace3 Library Tests", function()
   it("should load LibStub and AceAddon-3.0 successfully", function()
     -- LibStub is globally registered by WoW convention (and mocked in setup)
     assert.is_not_nil(LibStub)
@@ -10,5 +10,39 @@ describe("AceAddon-3.0 Test", function()
     local myAddon = AceAddon:NewAddon("TestAddon")
     assert.is_not_nil(myAddon)
     assert.are.equal("TestAddon", myAddon:GetName())
+  end)
+
+  it("should load newly added Ace3 libraries successfully", function()
+    -- Check that all newly added libraries are registered via LibStub
+    local AceEvent = LibStub("AceEvent-3.0", true)
+    assert.is_not_nil(AceEvent)
+
+    local AceDB = LibStub("AceDB-3.0", true)
+    assert.is_not_nil(AceDB)
+
+    local AceHook = LibStub("AceHook-3.0", true)
+    assert.is_not_nil(AceHook)
+
+    local AceConsole = LibStub("AceConsole-3.0", true)
+    assert.is_not_nil(AceConsole)
+
+    local AceDBOptions = LibStub("AceDBOptions-3.0", true)
+    assert.is_not_nil(AceDBOptions)
+
+    local AceConfig = LibStub("AceConfig-3.0", true)
+    assert.is_not_nil(AceConfig)
+    
+    local AceConfigRegistry = LibStub("AceConfigRegistry-3.0", true)
+    assert.is_not_nil(AceConfigRegistry)
+    
+    local AceConfigCmd = LibStub("AceConfigCmd-3.0", true)
+    assert.is_not_nil(AceConfigCmd)
+    
+    -- We are skipping AceGUI-3.0 and AceConfigDialog-3.0
+    local AceGUI = LibStub("AceGUI-3.0", true)
+    assert.is_nil(AceGUI)
+    
+    local AceConfigDialog = LibStub("AceConfigDialog-3.0", true)
+    assert.is_nil(AceConfigDialog)
   end)
 end)

--- a/spec/setup.lua
+++ b/spec/setup.lua
@@ -19,6 +19,17 @@ _G.C_Timer = {
   After = function(delay, callback) end
 }
 _G.IsLoggedIn = function() return true end
+_G.SlashCmdList = {}
+_G.hash_SlashCmdList = {}
+_G.GetLocale = function() return "enUS" end
+_G.GetBuildInfo = function() return "10.0.0", "12345", "Jan 1 2024", 100000 end
+_G.GetRealmName = function() return "TestRealm" end
+_G.UnitName = function() return "TestChar", "TestRealm" end
+_G.UnitClass = function() return "Warrior", "WARRIOR" end
+_G.UnitFactionGroup = function() return "Alliance", "Alliance" end
+_G.UnitRace = function() return "Human", "Human" end
+_G.GetCurrentRegion = function() return 1 end
+_G.GetCurrentRegionName = function() return "US" end
 
 if not _G.unpack and _G.table and _G.table.unpack then
   _G.unpack = _G.table.unpack
@@ -74,3 +85,23 @@ dofile("libs/CallbackHandler-1.0/CallbackHandler-1.0.lua")
 
 -- Load AceAddon-3.0
 dofile("libs/AceAddon-3.0/AceAddon-3.0.lua")
+
+-- Load AceEvent-3.0
+dofile("libs/AceEvent-3.0/AceEvent-3.0.lua")
+
+-- Load AceDB-3.0
+dofile("libs/AceDB-3.0/AceDB-3.0.lua")
+
+-- Load AceHook-3.0
+dofile("libs/AceHook-3.0/AceHook-3.0.lua")
+
+-- Load AceConsole-3.0
+dofile("libs/AceConsole-3.0/AceConsole-3.0.lua")
+
+-- Load AceDBOptions-3.0
+dofile("libs/AceDBOptions-3.0/AceDBOptions-3.0.lua")
+
+-- Load AceConfig-3.0 (Skip AceConfigDialog as it requires AceGUI)
+dofile("libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua")
+dofile("libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.lua")
+dofile("libs/AceConfig-3.0/AceConfig-3.0.lua")


### PR DESCRIPTION
Automated pull request generated by the Nanomite code tool.

Prompt:
We need to expand our Busted test environment for BetterBags to load more Ace3 libraries. Please do the following: 1. Update `install-deps.sh` to fetch the following libraries via SVN (using the idempotent functions we just added): `AceConfig-3.0`, `AceConsole-3.0`, `AceDB-3.0`, `AceDBOptions-3.0`, `AceEvent-3.0`, and `AceHook-3.0`. 2. Explicitly SKIP `AceGUI-3.0`. Do not check it out or load it. 3. Update `spec/setup.lua` to load (`dofile`) these new libraries in the correct dependency order after `AceAddon-3.0`. 4. You will likely need to add more mocked WoW global APIs to `spec/setup.lua` that these specific libraries expect (e.g., `SlashCmdList`, `hash_SlashCmdList`, `IsLoggedIn`, `GetLocale`, `UIParent`, etc.). 5. Update `spec/basic_spec.lua` to verify that all of these new libraries are successfully registered with `LibStub` and don't throw errors when loaded. 6. Ensure the local tests pass successfully by running `busted`. Remember: The system wrapper will automatically handle committing and creating the PR. Do not commit your changes.