### PR TITLE
feat: In BetterBags, update the bank tab sorting and drag-and-d...

### DIFF
--- a/frames/README.md
+++ b/frames/README.md
@@ -217,7 +217,29 @@ Tab management for bank views.
 - Click handlers
 - Toggle between single bank tab and multiple character bank tabs (retail only)
 - Tab visibility management (ShowTabByID/HideTabByID)
-- Automatic tab sorting by ID for consistent display order
+- Bank-type-aware tab sorting with strict section ordering
+- Drag-to-reorder with cross-section drag constraint
+
+**Bank Tab Sort Order (Retail):**
+
+Bank tabs are sorted into two distinct sections separated by their `bankType`:
+
+1. **Bank** (default, `Enum.BankType.Character`, `isDefault=true`) — always first
+2. User-created Bank tabs (`bankType=Character`), sorted by their saved order
+3. Purchase Bank tab (when available)
+4. **Warbank** (default, `Enum.BankType.Account`, `isDefault=true`) — always first in Warbank section
+5. User-created Warbank tabs (`bankType=Account`), sorted by their saved order
+6. Purchase Warbank tab (when available)
+7. **+** create tab — always last
+
+**Drag-to-Reorder Constraints:**
+
+User-created tabs can be reordered within their section via Shift+drag:
+- Bank tabs (Character bankType) can only be dropped within the Bank section
+- Warbank tabs (Account bankType) can only be dropped within the Warbank section
+- Cross-section drops are silently ignored
+
+This constraint is enforced in `CalculateOverlapTarget` by comparing the dragged tab's `bankType` against each candidate drop target's `bankType` before registering an overlap.
 
 ### Bag Slots (`bagslots.lua`)
 


### PR DESCRIPTION
All changes are complete and luacheck passes clean on `frames/tabs.lua`. Here's a summary of what was changed:

## Changes to `frames/tabs.lua`

**1. Added `const` import** (line 27-28):
```lua
---@class Constants: AceModule
local const = addon:GetModule("Constants")
```

**2. Rewrote `SortTabsByID` for bank-type-aware sorting:**

For `BAG_KIND.BANK`, tabs are now assigned to numbered sections based on their group's `bankType` and `isDefault` flag:

| Section | Contents |
|---------|----------|
| 1 | `Bank` default tab (`bankType=Character`, `isDefault=true`) |
| 2 | User-created Bank tabs (`bankType=Character`) — sorted by saved order |
| 3 | Purchase Bank tab (`id=-1`) |
| 4 | `Warbank` default tab (`bankType=Account`, `isDefault=true`) |
| 5 | User-created Warbank tabs (`bankType=Account`) — sorted by saved order |
| 6 | Purchase Warbank tab (`id=-2`) |
| 7 | `+` create tab (`id=0`) |

Backpack sorting is unchanged.

**3. Updated `CalculateOverlapTarget` with cross-section drag constraint:**

Before checking positional overlap, the function now looks up the dragged tab's `bankType`. If a candidate drop target has a different `bankType`, it's skipped (`validTarget = false`). This prevents Bank tabs from being dropped into the Warbank section and vice versa.

**4. Updated `frames/README.md`** to document the new sort order and drag-drop constraints.