### PR TITLE
feat: We have a bug in BetterBags related to dragging category ...

### DIFF
--- a/frames/README.md
+++ b/frames/README.md
@@ -103,9 +103,22 @@ Container for grouping items into categorized sections.
 **Key Features:**
 - Category-based item grouping
 - Expandable/collapsible sections
-- Drag-and-drop category assignment
+- Drag-and-drop category assignment (backpack and bank, with cross-type constraints)
 - Right-click section actions
 - Automatic sorting
+
+**Category Drag-and-Drop:**
+
+Section titles can be dragged onto group tabs to assign the category to a group. The following constraints are enforced:
+- Backpack categories can only be dropped onto backpack tabs.
+- Bank categories can only be dropped onto bank tabs.
+- Character Bank categories can only be dropped onto Character Bank group tabs (`bankType = Enum.BankType.Character`).
+- Warbank categories can only be dropped onto Warbank group tabs (`bankType = Enum.BankType.Account`).
+
+The `sectionFrame` module tracks three module-level fields during a drag:
+- `draggingCategory` — name of the category being dragged
+- `draggingKind` — `BagKind` of the source section (backpack or bank)
+- `draggingBankType` — `bankType` of the active bank group at drag start (nil for backpack drags)
 
 **Main Class:**
 ```lua

--- a/frames/tabs.lua
+++ b/frames/tabs.lua
@@ -482,6 +482,23 @@ function tabFrame:ResizeTabByIndex(ctx, index)
 		decoration:SetScript("OnEnter", function(frame)
 			-- Check if we're dragging a category
 			if sectionFrame.draggingCategory then
+				-- Validate that this tab accepts the dragged category:
+				-- 1. Tab frame kind must match the section's kind (no cross-bag drops).
+				-- 2. For bank tabs, the group's bankType must match draggingBankType
+				--    (Character Bank categories cannot go to Warbank groups and vice versa).
+				local isValidTarget = (sectionFrame.draggingKind == self.kind)
+				if isValidTarget and self.kind == const.BAG_KIND.BANK and sectionFrame.draggingBankType ~= nil then
+					local tabGroup = database:GetGroup(self.kind, tab.id)
+					if tabGroup and tabGroup.bankType ~= sectionFrame.draggingBankType then
+						isValidTarget = false
+					end
+				end
+
+				if not isValidTarget then
+					if originalOnEnter then originalOnEnter(frame) end
+					return
+				end
+
 				-- Track this as the drop target
 				sectionFrame.dragTargetTab = tab.id
 				-- Highlight the tab to indicate it's a valid drop target


### PR DESCRIPTION
All changes are complete and luacheck is clean. Here's a summary of what was done:

## Changes Made

### `frames/section.lua`

1. **Added `draggingKind` and `draggingBankType` module-level fields** (lines 54–55) — These track the bag kind and bank type of the section being dragged.

2. **Fixed `PerformDrop` nil kind crash** — The function now reads `self.draggingKind` (stored on the module) instead of `self.kind` (which doesn't exist on the `sectionFrame` module object). Also added an explicit nil guard.

3. **Enabled bank section dragging** — Removed the `if kind ~= const.BAG_KIND.BACKPACK then return end` restriction in `OnDragStart`. Bank sections can now be dragged.

4. **`OnDragStart` now stores all needed context** — When drag starts, `draggingKind` is stored, and for bank drags, `draggingBankType` is resolved from the currently active bank group.

5. **`OnDragStop` clears all fields** — `draggingKind` and `draggingBankType` are cleared alongside the existing `draggingCategory` cleanup.

6. **`ResetTabHighlights` now handles both bag types** — It resets highlights on both backpack and bank tabs after a drag ends.

7. **Tooltip updated** — The "Drag to a group tab" hint is now shown for all draggable sections (not just backpack), since bank sections can now be dragged too.

### `frames/tabs.lua`

8. **`OnEnter` validates drop compatibility** — Before highlighting a tab as a drop target, the handler checks:
   - `sectionFrame.draggingKind == self.kind` (prevents cross-bag drops: backpack ↔ bank)
   - For bank tabs: the tab group's `bankType` must match `sectionFrame.draggingBankType` (prevents Character Bank ↔ Warbank cross-drops)
   - Invalid targets fall through to the original `OnEnter` handler as if no drag is occurring.