### PR TITLE
Fix group rename errors, add bank tab context menu, and theme dialog

### DIFF
--- a/bags/README.md
+++ b/bags/README.md
@@ -72,6 +72,10 @@ Implements `BackpackBehavior` for the player's inventory bags.
 - Theme configuration
 - Cooldown event handling
 - Bag sorting
+- Group tab management with right-click context menu (Rename/Delete)
+
+**Group Tab Context Menu:**
+Right-clicking any user-created tab (ID > 1) shows a context menu with Rename and Delete options. The default "Backpack" tab (ID 1) does not show a context menu. Both `groups:RenameGroup` and `groups:DeleteGroup` are called with `const.BAG_KIND.BACKPACK` as the `kind` argument.
 
 ### bank.lua
 
@@ -83,6 +87,10 @@ Implements `BankBehavior` for the player's bank (retail version).
 - Warbank/Account bank tabs
 - Tab settings menu integration
 - Bank-specific event handling
+- Group tab management with right-click context menu (Rename/Delete)
+
+**Bank Group Tab Context Menu:**
+Right-clicking any user-created bank tab (non-default, ID > 0) shows a context menu with Rename and Delete options. Default bank groups (those with `isDefault = true`) do not show the context menu. Rename uses the `GroupDialog` module (pre-filled with the current name). Delete uses the `Question` module's `YesNo` dialog.
 
 **Critical Notes:**
 - BankPanel must be shown for `GetActiveBankType()` to work

--- a/bags/backpack.lua
+++ b/bags/backpack.lua
@@ -447,7 +447,7 @@ function backpack.proto:ShowRenameGroupDialog(groupID)
 				local name = f.EditBox:GetText()
 				if name and name ~= "" then
 					local ctx = context:New("RenameGroup")
-					groups:RenameGroup(ctx, f.data.groupID, name)
+					groups:RenameGroup(ctx, const.BAG_KIND.BACKPACK, f.data.groupID, name)
 				end
 			end,
 			OnShow = function(f)
@@ -463,7 +463,7 @@ function backpack.proto:ShowRenameGroupDialog(groupID)
 				local name = parent.EditBox:GetText()
 				if name and name ~= "" then
 					local ctx = context:New("RenameGroup")
-					groups:RenameGroup(ctx, parent.data.groupID, name)
+					groups:RenameGroup(ctx, const.BAG_KIND.BACKPACK, parent.data.groupID, name)
 				end
 				parent:Hide()
 			end,
@@ -494,7 +494,7 @@ function backpack.proto:ShowDeleteGroupConfirm(groupID)
 			button2 = L:G("Cancel"),
 			OnAccept = function(f)
 				local ctx = context:New("DeleteGroup")
-				groups:DeleteGroup(ctx, f.data.groupID)
+				groups:DeleteGroup(ctx, const.BAG_KIND.BACKPACK, f.data.groupID)
 			end,
 			timeout = 0,
 			whileDead = true,

--- a/frames/README.md
+++ b/frames/README.md
@@ -305,6 +305,32 @@ Individual bag slot buttons.
 - Purchase integration
 - Empty slot handling
 
+### Group Dialog (`groupdialog.lua`)
+
+Dialog for creating or renaming a group tab. Used by the bank to accept a name and optional bank type (Character Bank / Warbank).
+
+**Features:**
+- Pre-fillable input (for rename workflows — pass `initialValue` to `Show()`)
+- Configurable confirm-button label (pass `confirmText` to `Show()`)
+- Optional bank-type dropdown (shown when `showDropdown = true`)
+- Themed via the addon's active theme: the dialog is registered as a Simple window with the Themes module so it visually matches the rest of the UI
+
+**`Show()` Signature:**
+```lua
+groupDialog:Show(title, text, showDropdown, defaultBankType, onInput, initialValue, confirmText)
+```
+- `initialValue` — optional; pre-fills the edit box (used for rename)
+- `confirmText` — optional; overrides the confirm button label (default: "Create")
+
+### Question (`question.lua`)
+
+General-purpose modal dialog with pooled frame instances.
+
+**Modes:**
+- `AskForInput(title, text, onInput)` — edit-box prompt; calls `onInput(text)` on OK
+- `YesNo(title, text, yes, no)` — two-button confirmation
+- `Alert(title, text)` — single OK dismissal
+
 ## Version-Specific Implementations
 
 ### Classic Era (`era/`)

--- a/frames/groupdialog.lua
+++ b/frames/groupdialog.lua
@@ -7,7 +7,7 @@ local addon = LibStub('AceAddon-3.0'):GetAddon(addonName)
 local L = addon:GetModule('Localization')
 
 ---@class (exact) GroupDialog: AceModule
----@field frame Frame|DefaultPanelFlatTemplate
+---@field frame Frame
 ---@field text FontString
 ---@field yes Button|UIPanelButtonTemplate
 ---@field no Button|UIPanelButtonTemplate
@@ -22,13 +22,20 @@ function groupDialog:Initialize()
 
 	self.bankType = Enum.BankType and Enum.BankType.Character or 1
 
-	local f = CreateFrame('Frame', "BetterBagsGroupDialog", UIParent, "DefaultPanelFlatTemplate")
+	---@class Themes: AceModule
+	local themes = addon:GetModule('Themes')
+
+	local f = CreateFrame('Frame', "BetterBagsGroupDialog", UIParent)
 	self.frame = f
 	f:SetFrameStrata("DIALOG")
 	f:SetFrameLevel(600)
 	f:SetSize(300, 200)
 	f:SetPoint("CENTER")
 	f:Hide()
+
+	-- Apply the active theme's Simple decoration so the dialog matches the addon UI.
+	themes:RegisterSimpleWindow(f, L:G("New Group"))
+	themes:GetCurrentTheme().Simple(f)
 
 	self.text = f:CreateFontString(nil, "ARTWORK", "GameFontNormal")
 	self.text:SetTextColor(1, 1, 1)
@@ -93,16 +100,27 @@ function groupDialog:Hide()
 	end
 end
 
-function groupDialog:Show(title, text, showDropdown, defaultBankType, onInput)
+---@param title string
+---@param text string
+---@param showDropdown boolean
+---@param defaultBankType? number
+---@param onInput fun(name: string, bankType: number)
+---@param initialValue? string Pre-fill the input box with this value (e.g., current group name for rename).
+---@param confirmText? string Label for the confirm button (defaults to "Create").
+function groupDialog:Show(title, text, showDropdown, defaultBankType, onInput, initialValue, confirmText)
 	if self.open then return end
 
 	if not self.frame then
 		self:Initialize()
 	end
 
-	self.frame:SetTitle(title)
+	---@class Themes: AceModule
+	local themes = addon:GetModule('Themes')
+	themes:SetTitle(self.frame, title)
+
 	self.text:SetText(text)
-	self.input:SetText("")
+	self.input:SetText(initialValue or "")
+	self.yes:SetText(confirmText or L:G("Create"))
 
 	self.bankType = defaultBankType or (Enum.BankType and Enum.BankType.Character or 1)
 


### PR DESCRIPTION
This PR addresses several issues related to group and tab management.

- Fixes a Lua error during group rename and delete operations by correcting the argument order (`kind` and `groupID`).
- Implements the right-click context menu for bank tabs, enabling rename and delete functionality.
- Updates the group dialog box to use the active theme's simple panel decoration rather than a hardcoded style for better UI consistency.