### PR TITLE
Fix free space count for bank and warbank tabs

### DIFF
--- a/core/constants.lua
+++ b/core/constants.lua
@@ -54,6 +54,12 @@ if addon.isRetail then
     [Enum.BagIndex.AccountBankTab_4] = Enum.BagIndex.AccountBankTab_4,
     [Enum.BagIndex.AccountBankTab_5] = Enum.BagIndex.AccountBankTab_5,
   }
+  -- Named aliases used as context markers by UpdateFreeSlots to distinguish
+  -- character bank from account bank (warbank) mode. The retail BANK_TAB table
+  -- uses integer enum keys only, so these named keys are required for the
+  -- ctx:Set("bagid", ...) calls in RefreshBags to produce non-nil values.
+  const.BANK_TAB.BANK = Enum.BagIndex.Characterbanktab
+  const.BANK_TAB.ACCOUNT_BANK_1 = Enum.BagIndex.AccountBankTab_1
 else
   -- BankTab is an enum for the different bank tabs.
   ---@enum BankTab

--- a/data/items.lua
+++ b/data/items.lua
@@ -726,7 +726,11 @@ function items:UpdateFreeSlots(ctx, kind)
 	local tab = ctx:Get("bagid")
 	if kind == const.BAG_KIND.BANK then
 		if tab == const.BANK_TAB.BANK then
+			-- Character bank: sum free slots across all character bank tabs.
 			baglist = const.BANK_BAGS
+		elseif const.ACCOUNT_BANK_BAGS and tab == const.BANK_TAB.ACCOUNT_BANK_1 then
+			-- Account bank (warbank): sum free slots across all warbank tabs.
+			baglist = const.ACCOUNT_BANK_BAGS
 		else
 			baglist = { [tab] = tab }
 		end


### PR DESCRIPTION
This PR fixes an issue where the free space count incorrectly displayed the same value when switching between standard bank and warbank tabs. The calculation logic has been updated so that selecting a standard bank tab correctly shows the total free space across all standard bank tabs, while selecting a warbank tab shows the total free space for all warbank tabs. These changes are implemented safely to maintain compatibility across both retail and non-retail clients.