### PR TITLE
Fix mouse wheel scroll interception by child frames

### DIFF
--- a/frames/README.md
+++ b/frames/README.md
@@ -146,6 +146,15 @@ Flexible grid system for arranging UI elements.
 - Flexible spacing
 - Sort support
 
+**Mouse Wheel Scroll Propagation:**
+
+WoW does not bubble mouse wheel events up the parent-child hierarchy. Each WowScrollBox (created by `grid:Create`) automatically registers an `OnMouseWheel` handler via the template, which would intercept all scroll events — even on non-scrollable inner grids (e.g. section content grids).
+
+To ensure scroll events reach the outer bag container:
+- `EnableMouseWheelScroll(false)` is called on all section content grids (non-scrollable inner grids)
+- Mouse wheel is disabled on all item buttons (`ContainerFrameItemButtonTemplate` enables it via its mixin)
+- Events then fall through to the outer bag grid's WowScrollBox, which handles scrolling
+
 **Main Class:**
 ```lua
 ---@class Grid
@@ -161,6 +170,7 @@ Flexible grid system for arranging UI elements.
 - `Draw(options)` - Render grid layout
 - `Sort(fn)` - Sort cells
 - `DislocateCell(id)` - Remove cell visually
+- `EnableMouseWheelScroll(enabled)` - Enable or disable mouse wheel scrolling on this grid's scroll box
 
 ### List Layout (`list.lua`)
 

--- a/frames/bagslots.lua
+++ b/frames/bagslots.lua
@@ -113,6 +113,9 @@ function BagSlots:CreatePanel(ctx, kind)
   b.content:GetContainer():SetPoint("BOTTOMRIGHT", b.frame, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, 12)
   b.content.maxCellWidth = 10
   b.content:HideScrollBar()
+  -- Bag slots grid is not scrollable; disable mouse wheel so scroll events
+  -- pass through to the outer scrollable bag container.
+  b.content:EnableMouseWheelScroll(false)
   b.content:Show()
 
   local bags = kind == const.BAG_KIND.BACKPACK and const.BACKPACK_ONLY_BAGS_LIST or const.BANK_ONLY_BAGS_LIST

--- a/frames/classic/currency.lua
+++ b/frames/classic/currency.lua
@@ -161,6 +161,9 @@ function currency:CreateIconGrid(parent)
   g:GetContainer():SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", const.OFFSETS.BAG_LEFT_INSET+4, const.OFFSETS.BAG_BOTTOM_INSET+3)
   g:GetContainer():SetWidth(200)
   g:HideScrollBar()
+  -- Currency grid is not scrollable; disable mouse wheel so scroll events
+  -- pass through to the outer scrollable bag container.
+  g:EnableMouseWheelScroll(false)
   g.maxCellWidth = 7
   b.iconGrid = g
 

--- a/frames/currency.lua
+++ b/frames/currency.lua
@@ -118,6 +118,9 @@ function currency:CreateIconGrid(parent)
   g:GetContainer():SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", const.OFFSETS.BAG_LEFT_INSET+4, const.OFFSETS.BAG_BOTTOM_INSET+3)
   g:GetContainer():SetWidth(200)
   g:HideScrollBar()
+  -- Currency grid is not scrollable; disable mouse wheel so scroll events
+  -- pass through to the outer scrollable bag container.
+  g:EnableMouseWheelScroll(false)
   g.maxCellWidth = 7
   b.iconGrid = g
 

--- a/frames/era/bagslots.lua
+++ b/frames/era/bagslots.lua
@@ -58,6 +58,9 @@ function BagSlots:CreatePanel(ctx, kind)
   b.content:GetContainer():SetPoint("BOTTOMRIGHT", b.frame, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, 12)
   b.content.maxCellWidth = 10
   b.content:HideScrollBar()
+  -- Bag slots grid is not scrollable; disable mouse wheel so scroll events
+  -- pass through to the outer scrollable bag container.
+  b.content:EnableMouseWheelScroll(false)
   b.content:Show()
 
   local bags = kind == const.BAG_KIND.BACKPACK and const.BACKPACK_ONLY_BAGS_LIST or const.BANK_ONLY_BAGS_LIST

--- a/frames/era/item.lua
+++ b/frames/era/item.lua
@@ -341,6 +341,12 @@ function itemFrame:_DoCreate()
   button:SetSize(37, 37)
   button:RegisterForDrag("LeftButton")
   button:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+  -- ContainerFrameItemButtonTemplate enables mouse wheel via its mixin, which would
+  -- intercept scroll events before they reach the parent WowScrollBox container.
+  -- Clear the handler and explicitly disable mouse wheel on this button so that
+  -- scroll events fall through to the outer scrollable bag frame.
+  button:SetScript("OnMouseWheel", nil)
+  button:EnableMouseWheel(false)
   button:SetAllPoints(p)
   i.button = button
 

--- a/frames/era/itemrow.lua
+++ b/frames/era/itemrow.lua
@@ -92,6 +92,11 @@ function item:_DoCreate(ctx)
   ---@field BattlepayItemTexture Texture
   local rowButton = CreateFrame("Button", name, p, "ContainerFrameItemButtonTemplate")
   rowButton:SetAllPoints(i.frame)
+  -- ContainerFrameItemButtonTemplate enables mouse wheel via its mixin, which would
+  -- intercept scroll events before they reach the parent WowScrollBox container.
+  -- Clear the handler and explicitly disable mouse wheel so scroll events fall through.
+  rowButton:SetScript("OnMouseWheel", nil)
+  rowButton:EnableMouseWheel(false)
   i.rowButton = rowButton
 
   -- Button properties are set when setting the item,

--- a/frames/grid.lua
+++ b/frames/grid.lua
@@ -145,6 +145,14 @@ function gridProto:HideScrollBar()
   self.bar:SetAttribute("nodeignore", true)
 end
 
+-- EnableMouseWheelScroll enables or disables mouse wheel scrolling on this grid's
+-- scroll box. Disable this on non-scrollable grids (e.g. section content grids)
+-- so mouse wheel events fall through to the outer scrollable bag container.
+---@param enabled boolean
+function gridProto:EnableMouseWheelScroll(enabled)
+  self.frame:EnableMouseWheel(enabled)
+end
+
 function gridProto:SortVertical()
   self.sortVertical = true
 end

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -824,6 +824,12 @@ function itemFrame:_DoCreate(_)
 
 	button:RegisterForDrag("LeftButton")
 	button:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+	-- ContainerFrameItemButtonTemplate enables mouse wheel via its mixin, which would
+	-- intercept scroll events before they reach the parent WowScrollBox container.
+	-- Clear the handler and explicitly disable mouse wheel on this button so that
+	-- scroll events fall through to the outer scrollable bag frame.
+	button:SetScript("OnMouseWheel", nil)
+	button:EnableMouseWheel(false)
 	i.button = button
 	button:SetAllPoints(p)
 

--- a/frames/itemrow.lua
+++ b/frames/itemrow.lua
@@ -129,6 +129,7 @@ function item.itemRowProto:ClearItem(ctx)
   self.frame:Hide()
   self.rowButton:Hide()
   self.rowButton:SetScript("OnMouseWheel", nil)
+  self.rowButton:EnableMouseWheel(false)
   self.rowButton:SetScript("OnEnter", function(s)
     ---@cast s ItemButton
     s.HighlightTexture:Show()
@@ -203,6 +204,11 @@ function item:_DoCreate(ctx)
   ---@class ItemButton
   local rowButton = CreateFrame("ItemButton", name, p, "ContainerFrameItemButtonTemplate")
   rowButton:SetAllPoints(i.frame)
+  -- ContainerFrameItemButtonTemplate enables mouse wheel via its mixin, which would
+  -- intercept scroll events before they reach the parent WowScrollBox container.
+  -- Clear the handler and explicitly disable mouse wheel so scroll events fall through.
+  rowButton:SetScript("OnMouseWheel", nil)
+  rowButton:EnableMouseWheel(false)
   i.rowButton = rowButton
 
   -- Button properties are set when setting the item,

--- a/frames/section.lua
+++ b/frames/section.lua
@@ -690,6 +690,9 @@ function sectionFrame:_DoCreate()
   local content = grid:Create(s.frame)
   content:Show()
   content:HideScrollBar()
+  -- Section content grids are not scrollable; disable mouse wheel so scroll
+  -- events pass through to the outer scrollable bag container instead.
+  content:EnableMouseWheelScroll(false)
   s.content = content
   f:Show()
   return s


### PR DESCRIPTION
Resolves an issue where mouse wheel scrolling in large containers (like the bank frame) was being intercepted by non-scrollable child frames. By explicitly disabling mouse wheel scrolling on inner elements like the currency bar, bag slots panel, and section content grids, scroll events now correctly reach the parent container. These fixes have been applied comprehensively across the Retail, Classic, and Classic Era versions of the addon.