### PR TITLE
fix: remove trailing whitespace in core/database.lua

### DIFF
--- a/core/database.lua
+++ b/core/database.lua
@@ -1076,7 +1076,7 @@ function DB:Migrate()
     local oldGroups = DB.data.profile.groups
     local oldCategoryToGroup = DB.data.profile.categoryToGroup
     local oldGroupCounter = DB.data.profile.groupCounter
-    
+
     -- Check if it's already scoped (e.g. fresh install with new defaults)
     -- We must ensure oldGroups[1] isn't just the old Backpack group.
     -- A scoped namespace will NOT have a 'name' field, whereas a group object will.
@@ -1084,7 +1084,7 @@ function DB:Migrate()
     if oldGroups and type(oldGroups) == "table" then
       local maybeBackpackNamespace = oldGroups[const.BAG_KIND.BACKPACK]
       local maybeBankNamespace = oldGroups[const.BAG_KIND.BANK]
-      
+
       -- If it's a namespace, it shouldn't have an 'id' or 'name' directly on it
       if (maybeBackpackNamespace and type(maybeBackpackNamespace) == "table" and maybeBackpackNamespace.name == nil) or
          (maybeBankNamespace and type(maybeBankNamespace) == "table" and maybeBankNamespace.name == nil) then


### PR DESCRIPTION
## Summary

- Removed trailing whitespace from two blank lines inside `DB:Migrate()` in `core/database.lua` (lines 1079 and 1087).
- These whitespace-only lines caused `luacheck` to report linting warnings.
- After this fix, `luacheck .` reports **0 warnings / 0 errors** across all 110 files.

## Why

Keeping the codebase clean of trailing whitespace ensures consistent formatting, satisfies pre-commit hooks, and prevents unnecessary noise in `luacheck` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)