### PR TITLE
ci: install addon deps via install-deps.sh before running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
+      - name: Cache addon dependencies
+        uses: actions/cache@v4
+        with:
+          path: ./libs
+          key: addon-deps-${{ hashFiles('install-deps.sh') }}
+
+      - name: Install addon dependencies
+        run: bash install-deps.sh
+
       - name: Install Lua
         uses: leafo/gh-actions-lua@v10
         with:


### PR DESCRIPTION
## What changed

Three new steps are added to the test workflow before Lua is installed:

- **Install SVN** — runs `apt-get update && apt-get install -y subversion` so that `install-deps.sh` can fetch libraries hosted on SVN (e.g. LibStub, AceAddon-3.0). The update call prevents failures on runners with a stale package index.
- **Cache addon dependencies** — uses `actions/cache@v4` keyed on the SHA hash of `install-deps.sh`. When the script is unchanged the cached `./libs` directory is restored and the clone/checkout guards in the script skip re-fetching, keeping CI fast. When `install-deps.sh` changes the cache misses and a fresh fetch runs.
- **Install addon dependencies** — executes `bash install-deps.sh` to clone/checkout all required libraries so they are present before tests start.

## Why

Tests were failing (or being skipped entirely) because LibStub, AceAddon-3.0 and other dependencies in `./libs` were never fetched in CI. `install-deps.sh` already contains the correct clone/checkout logic; this PR simply invokes it at the right point in the workflow with the SVN binary it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)