### PR TITLE
fix: sort grid sections correctly on bank open and tab switch

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -110,6 +110,7 @@ Implements the category-based grid view with sections.
 - **Free Space Display**: Shows available bag slots
 - **Smart Sorting**: Sorts sections and items within sections
 - **Dynamic Sections**: Creates/removes sections as needed
+- **Sort After Wipe**: Tracks a `sortRequired` flag so that a section sort always runs after the view is wiped, even when the wipe and the subsequent rebuild happen under different context objects (e.g. `SwitchToGroup` wipes with one context, but the refresh pipeline creates a fresh context without `wipe=true`).
 
 #### Key Functions
 


### PR DESCRIPTION
## Summary

- Sections in the bank grid view were not sorted when opening the bank or switching tabs, and only became sorted after a manual bag refresh.
- Root cause: a context-boundary gap in the refresh pipeline — `SwitchToGroup`/`SwitchToBlizzardTab` wipes the view with a context that carries `wipe=true`, but the subsequent `refresh:RequestUpdate` → `ExecutePendingUpdates` path creates a **fresh** context without that flag, so `GridView`'s sort guard (`ctx:GetBool('wipe')`) evaluated to `false` and the sort was skipped.

## Fix

Added a `view.sortRequired` boolean flag on the long-lived view object:

- **`Wipe()`** sets `view.sortRequired = true` whenever the view is wiped.
- **`GridView()`** checks `ctx:GetBool('wipe') or view.sortRequired` and clears the flag immediately before sorting, so the sort fires exactly once after each wipe regardless of which context the rebuild uses.
- **`views:NewGrid()`** initializes the flag to `false`.

## Files Changed

- `views/gridview.lua` — core fix: set/check/clear `sortRequired`
- `views/README.md` — document the new flag
- `.context/patterns.md` — add reusable pattern for context-boundary gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)