### PR TITLE
fix: separate bank slot view and purchase buttons into distinct frames

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,7 +26,6 @@ globals = {
 	"AccountBankPanel",
 	"BankPanel",
 	"BankPanelMixin",
-	"BankPanelPurchaseTabButtonMixin",
 	"BetterBags_ToggleBags",
 	"BetterBags_ToggleSearch",
 	"ButtonInventorySlot",


### PR DESCRIPTION
## Summary

- Splits each bank slot button into two mutually exclusive sub-buttons inside a shared container frame.
- **`viewButton`** (plain `Button`) is shown when the slot is purchased; handles left-click (tab selection) and right-click (tab config) via a scoped `OnClick` handler.
- **`purchaseButton`** (`BankPanelPurchaseButtonScriptTemplate`) is shown when the slot is unpurchased; opens the Blizzard bank tab purchase dialog natively through the template — no `OnClick` override needed or allowed.
- A shared `showSlotTooltip` closure is attached to both sub-buttons so hovering either one renders the correct tooltip.
- Removes `BankPanelPurchaseTabButtonMixin` from `.luacheckrc` globals since it is no longer referenced.

## Why

The previous implementation applied `BankPanelPurchaseButtonScriptTemplate` to a single button and tried to forward clicks to `BankPanelPurchaseTabButtonMixin:OnClick` from within the addon's own `OnClick` handler. WoW's secure-call system blocks this because calling into a protected mixin from an unsecured script taints the execution path and raises `ADDON_ACTION_FORBIDDEN`. Using two separate, purpose-built buttons avoids the issue entirely: the purchase button's secure click path is never touched by addon code.