### PR TITLE
feat: remove obsolete purchase bank tab buttons and toggle flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ To show Character Bank Tabs, turn on the option in the Bank Menu. This allows al
 </div>
 
 ### Warbank Tabs
-To purchase Warbank tabs, click on the `Purchase Warbank Tab` button, then click purchase on the Blizzard pop-up.  
 Warbank tabs can be renamed and certain item types can be assigned to them by right-clicking on the tab at the bottom of the bank. This will bring up the Blizzard prompt to make any changes. Depositing items into the Warbank tabs will deposit them using Blizzard's rules for depositting items into the Warbank.
 
 <div align="center" style="text-align:center">

--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -327,34 +327,6 @@ function bank.proto:GenerateGroupTabs(ctx)
 		self:SetupPlusTabTooltip(ctx)
 	end
 
-	if C_Bank and C_Bank.CanPurchaseBankTab and C_Bank.HasMaxBankTabs then
-		if C_Bank.CanPurchaseBankTab(Enum.BankType.Character) and not C_Bank.HasMaxBankTabs(Enum.BankType.Character) then
-			if not self.bag.tabs:TabExistsByID(-1) then
-				self.bag.tabs:AddTab(ctx, L:G("Purchase Bank Tab"), -1, nil, nil, self.bag.frame, "BankPanelPurchaseButtonScriptTemplate")
-				local purchaseTab = self.bag.tabs:GetTabByName(L:G("Purchase Bank Tab"))
-				if purchaseTab then purchaseTab:SetAttribute("overrideBankType", Enum.BankType.Character) end
-			else
-				self.bag.tabs:ShowTabByID(-1)
-			end
-		elseif self.bag.tabs:TabExistsByID(-1) then
-			self.bag.tabs:HideTabByID(-1)
-		end
-
-		-- Disable rendering the purchase warbank tab button for now
-		local ENABLE_WARBANK_PURCHASE_TAB = false
-		if ENABLE_WARBANK_PURCHASE_TAB and addon.isRetail and C_Bank.CanPurchaseBankTab(Enum.BankType.Account) and not C_Bank.HasMaxBankTabs(Enum.BankType.Account) then
-			if not self.bag.tabs:TabExistsByID(-2) then
-				self.bag.tabs:AddTab(ctx, L:G("Purchase Warbank Tab"), -2, nil, nil, self.bag.frame, "BankPanelPurchaseButtonScriptTemplate")
-				local purchaseTab = self.bag.tabs:GetTabByName(L:G("Purchase Warbank Tab"))
-				if purchaseTab then purchaseTab:SetAttribute("overrideBankType", Enum.BankType.Account) end
-			else
-				self.bag.tabs:ShowTabByID(-2)
-			end
-		elseif self.bag.tabs:TabExistsByID(-2) then
-			self.bag.tabs:HideTabByID(-2)
-		end
-	end
-
 	self.bag.tabs:SortTabsByID()
 	self.bag.tabs:MoveToEnd(L:G("New Group"))
 

--- a/frames/contextmenu.lua
+++ b/frames/contextmenu.lua
@@ -214,9 +214,6 @@ function contextMenu:CreateContextMenu(bag)
 	})
 
 	if bag.kind == const.BAG_KIND.BANK then
-		-- Purchase bank tab buttons removed from context menu.
-		-- They are now implemented as persistent tab buttons on the bank frame
-		-- to avoid taint issues (see bags/bank.lua OnCreate).
 		table.insert(menuList, {
 			text = L:G("Sort Bank"),
 			notCheckable = true,

--- a/frames/tabs.lua
+++ b/frames/tabs.lua
@@ -176,7 +176,7 @@ function tabFrame:SortTabsByID()
 	if self.kind == const.BAG_KIND.BANK then
 		-- Bank tab sort order:
 		--   Bank (default, Character) → user Bank tabs → Warbank (default, Account)
-		--   → user Warbank tabs → purchase tabs → "+" tab
+		--   → user Warbank tabs → "+" tab
 		-- This groups bank and warbank tabs into clearly separated sections.
 		local charBankType = Enum.BankType and Enum.BankType.Character or 1
 		local accountBankType = Enum.BankType and Enum.BankType.Account or 2
@@ -185,16 +185,12 @@ function tabFrame:SortTabsByID()
 		-- Section values:
 		--   1 = Bank default (Character bankType, isDefault)
 		--   2 = User-created Bank tabs (Character bankType)
-		--   3 = Purchase Bank tab (id=-1)
 		--   4 = Warbank default (Account bankType, isDefault)
 		--   5 = User-created Warbank tabs (Account bankType)
-		--   6 = Purchase Warbank tab (id=-2)
 		--   7 = "+" create tab (id=0)
 		--   8 = Unknown/fallback
 		local function getBankTabSection(tab)
 			if tab.id == 0 then return 7, 0 end   -- "+" always last
-			if tab.id == -1 then return 3, 0 end   -- Purchase Bank tab
-			if tab.id == -2 then return 6, 0 end   -- Purchase Warbank tab
 			if tab.id and tab.id > 0 then
 				local group = database:GetGroup(self.kind, tab.id)
 				if group then


### PR DESCRIPTION
## What changed

- **`bags/bank.lua`**: Removed the `GenerateGroupTabs` block that created tab-buttons for "Purchase Bank Tab" (id=-1) and "Purchase Warbank Tab" (id=-2), including the dead-code `ENABLE_WARBANK_PURCHASE_TAB = false` flag.
- **`frames/tabs.lua`**: Removed the `getBankTabSection` cases for id=-1 and id=-2, and updated the sort-order comment to drop the purchase-tab sections.
- **`frames/contextmenu.lua`**: Removed a stale comment block that explained the old purchase-button implementation.
- **`README.md`**: Removed the documentation line instructing users to click "Purchase Warbank Tab" to buy tabs.

## Why

These purchase buttons were made obsolete by the new bank system where Blizzard handles warbank tab purchasing natively. The warbank purchase toggle was already hardcoded to `false` as a placeholder, making the dead code safe to remove entirely.