### PR TITLE
feat: disable bottom tabs while bank slots panel is open

### DIFF
--- a/frames/README.md
+++ b/frames/README.md
@@ -244,6 +244,11 @@ Tab management for bank views.
 - Bank-type-aware tab sorting with strict section ordering
 - Drag-to-reorder with cross-section drag constraint
 - Icon-only tab minimum width enforcement (50px)
+- Functional disable state (`SetTabsDisabled`) used by the bank slots panel
+
+**Tab Disable State:**
+
+`SetTabsDisabled(disabled)` sets a `tabsDisabled` flag on the tab container and dims the tab bar to 50% alpha when disabled. While disabled, all `OnClick` and `OnMouseDown` handlers silently return early, preventing tab switching and drag-to-reorder. The bank slots panel calls this when opening (disable) and after the fade-out animation completes (re-enable), so bottom tabs are inert while the per-Blizzard-tab slot filter is active.
 
 **Icon-Only Tab Sizing:**
 
@@ -314,7 +319,9 @@ Slide-out panel that appears above the bank frame showing all possible Blizzard 
 - `SelectTab(ctx, bagIndex)` — selects the given tab, deselects others, and calls `bank.behavior:SwitchToBlizzardTab()`
 - `SelectFirstTab(ctx)` — selects the first available tab (called automatically on fade-in)
 - `OpenTabConfig(bagIndex)` — opens the Blizzard tab settings dialog for the given bag index
-- `Show(callback?)` / `Hide(callback?)` / `IsShown()` — animation-aware show/hide
+- `Show(callback?)` — plays fade-in animation; **immediately calls `tabs:SetTabsDisabled(true)`** so the bottom group tabs are non-interactive while the panel is open
+- `Hide(callback?)` — plays fade-out animation; `SetTabsDisabled(false)` is called after the animation completes (in `fadeOutGroup.OnFinished`)
+- `IsShown()` — returns whether the underlying frame is visible
 
 **Tab Config Dialog — Reliable Icon Selection:**
 

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -167,6 +167,11 @@ function BankSlots.bankSlotsPanelProto:Show(callback)
       callback()
     end
   end
+  -- Disable bottom tabs while the bank slots panel is open so clicking them
+  -- does nothing (they have no effect while filtering by Blizzard tab slot).
+  if addon.Bags and addon.Bags.Bank and addon.Bags.Bank.tabs then
+    addon.Bags.Bank.tabs:SetTabsDisabled(true)
+  end
   self.fadeInGroup:Play()
 end
 
@@ -512,6 +517,10 @@ function BankSlots:CreatePanel(ctx, bagFrame)
       addon.Bags.Bank.blizzardBankTab = nil
       items:ClearBankCache(ectx)
       events:SendMessage(ectx, 'bags/RefreshBank')
+      -- Re-enable the bottom tabs now that the bank slots panel is fully hidden.
+      if addon.Bags.Bank.tabs then
+        addon.Bags.Bank.tabs:SetTabsDisabled(false)
+      end
     end
   end)
 

--- a/frames/tabs.lua
+++ b/frames/tabs.lua
@@ -439,6 +439,7 @@ function tabFrame:ResizeTabByIndex(ctx, index)
 
 	if not tab.sabtClick then
 		addon.SetScript(decoration, "OnClick", function(ectx, _, button)
+			if self.tabsDisabled then return end
 			if tab.onClick then
 				tab.onClick()
 				return
@@ -459,6 +460,7 @@ function tabFrame:ResizeTabByIndex(ctx, index)
 		-- Enable drag-to-reorder for reorderable tabs (group tabs, not Bank/"+" tabs)
 		if tabs:IsTabReorderable(self.kind, tab) then
 			decoration:SetScript("OnMouseDown", function(_, button)
+				if self.tabsDisabled then return end
 				if button == "LeftButton" and IsShiftKeyDown() then
 					tabs:StartTabDrag(tab, self)
 				end
@@ -564,6 +566,15 @@ function tabFrame:SetTabByIndex(ctx, index)
 			end
 		end
 	end
+end
+
+-- SetTabsDisabled disables or re-enables all tab click interactions and
+-- dims the tab bar to signal that tabs are not interactive. Used by the
+-- bank slots panel to prevent tab switching while it is open.
+---@param disabled boolean
+function tabFrame:SetTabsDisabled(disabled)
+	self.tabsDisabled = disabled
+	self.frame:SetAlpha(disabled and 0.5 or 1.0)
 end
 
 ---@param index number
@@ -698,6 +709,7 @@ function tabs:Create(parent, kind)
 	container.buttonToName = {}
 	container.tabCount = 0
 	container.selectedTab = nil  -- Initialize to nil to avoid undefined state
+	container.tabsDisabled = false
 	return container
 end
 


### PR DESCRIPTION
## What changed

When the bank slots panel (the top Blizzard-tab selector) is shown, the bottom group-tab bar is now functionally disabled until the panel is fully hidden again.

## Why

The bottom tabs do nothing while the bank slots panel is filtering items by Blizzard tab slot, so clicking them was silently ineffective. This can confuse users into thinking the UI is broken.

## How

- **`frames/tabs.lua`**: Added `SetTabsDisabled(disabled)` to `tabFrame`. Sets a `tabsDisabled` flag and dims the tab bar to 50% alpha. `OnClick` and `OnMouseDown` handlers return early when the flag is set, blocking tab switching and drag-to-reorder.
- **`frames/bankslots.lua`**: Calls `SetTabsDisabled(true)` on `Show()` entry and `SetTabsDisabled(false)` in `fadeOutGroup.OnFinished`, so tabs are re-enabled only after the fade-out animation completes.
- **`frames/README.md`**: Updated documentation to describe the new disable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)