### PR TITLE
fix: enforce bank min width to match bottom slots panel width

### DIFF
--- a/frames/README.md
+++ b/frames/README.md
@@ -333,7 +333,7 @@ After the fade-out animation completes (`fadeOutGroup.OnFinished`):
 
 **Key Methods:**
 - `CreatePanel(ctx, bagFrame)` — factory; returns a `bankSlotsPanel` (retail-only; returns nil on Classic/Era)
-- `Draw(ctx)` — refreshes all slot button visuals from the current C_Bank tab data
+- `Draw(ctx)` — refreshes all slot button visuals from the current C_Bank tab data; also enforces that `bagFrame` width is at least as wide as the panel
 - `SelectTab(ctx, bagIndex)` — selects the given tab, deselects others, and calls `bank.behavior:SwitchToBlizzardTab()`
 - `SelectFirstTab(ctx)` — selects the first available tab (called automatically on fade-in)
 - `OpenTabConfig(bagIndex)` — opens the Blizzard tab settings dialog for the given bag index

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -151,6 +151,13 @@ function BankSlots.bankSlotsPanelProto:Draw(ctx)
   self.frame:SetWidth(w + const.OFFSETS.BAG_LEFT_INSET + -const.OFFSETS.BAG_RIGHT_INSET + 4)
   -- Height = content height + top inset (12) + bottom inset (12).
   self.frame:SetHeight(h + 24)
+
+  -- Enforce minimum bag frame width so the main bank window is never
+  -- narrower than the bank tab panel anchored below it.
+  local panelWidth = self.frame:GetWidth()
+  if self.bagFrame:GetWidth() < panelWidth then
+    self.bagFrame:SetWidth(panelWidth)
+  end
 end
 
 function BankSlots.bankSlotsPanelProto:SetShown(shown)

--- a/views/bagview.lua
+++ b/views/bagview.lua
@@ -199,6 +199,19 @@ local function BagView(view, ctx, bag, slotInfo, callback)
   if bag.tabs and w < bag.tabs.width then
     w = bag.tabs.width
   end
+  -- When the bank tab slots panel is visible it is anchored to the bottom-left
+  -- of the bag frame and may be wider than the item grid.  Compute the minimum
+  -- content width so that bagWidth (w + insets + scrollbar) exactly equals the
+  -- panel frame width, preventing the panel from overflowing past the right edge.
+  if bag.slots and bag.slots:IsShown() then
+    local minW = bag.slots.frame:GetWidth()
+      - const.OFFSETS.BAG_LEFT_INSET
+      + const.OFFSETS.BAG_RIGHT_INSET
+      - const.OFFSETS.SCROLLBAR_WIDTH
+    if w < minW then
+      w = minW
+    end
+  end
   if h == 0 then
     h = 40
   end

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -575,6 +575,19 @@ local function GridView(view, ctx, bag, slotInfo, callback)
   if bag.tabs and w < bag.tabs.width then
     w = bag.tabs.width
   end
+  -- When the bank tab slots panel is visible it is anchored to the bottom-left
+  -- of the bag frame and may be wider than the item grid.  Compute the minimum
+  -- content width so that bagWidth (w + insets + scrollbar) exactly equals the
+  -- panel frame width, preventing the panel from overflowing past the right edge.
+  if bag.slots and bag.slots:IsShown() then
+    local minW = bag.slots.frame:GetWidth()
+      - const.OFFSETS.BAG_LEFT_INSET
+      + const.OFFSETS.BAG_RIGHT_INSET
+      - const.OFFSETS.SCROLLBAR_WIDTH
+    if w < minW then
+      w = minW
+    end
+  end
   if h < 100 then
     h = 100
   end


### PR DESCRIPTION
## What changed

The bank tab slots panel is anchored below the bag frame and can be wider than the item grid, causing it to visually overflow past the right edge of the bank window.

## Fix

- **`frames/bankslots.lua` — `Draw()`**: After computing and setting the panel's own width, immediately clamp `bagFrame:GetWidth()` to be at least as wide as the panel. This handles the first draw and any redraws triggered by `BANK_TAB_SETTINGS_UPDATED` / `PLAYER_ACCOUNT_BANK_TAB_SLOTS_CHANGED`.
- **`views/gridview.lua` and `views/bagview.lua`**: Added a slots panel floor alongside the existing `bag.tabs.width` floor. The minimum content width is back-calculated from the panel frame width using the same inset/scrollbar constants so that `bagWidth = w + insets + scrollbar` equals the panel frame width exactly (no overshoot).

The `bag.slots:IsShown()` guard ensures the constraint only applies when the panel is active (bank open), leaving backpack rendering and non-bank views completely unaffected.