### PR TITLE
fix: add missing bank constants for CharacterBankTab_7, Reagentbank, and AccountBankTab_6

### DIFF
--- a/core/constants.lua
+++ b/core/constants.lua
@@ -124,6 +124,8 @@ if addon.isRetail then
     [Enum.BagIndex.CharacterBankTab_4] = Enum.BagIndex.CharacterBankTab_4,
     [Enum.BagIndex.CharacterBankTab_5] = Enum.BagIndex.CharacterBankTab_5,
     [Enum.BagIndex.CharacterBankTab_6] = Enum.BagIndex.CharacterBankTab_6,
+    [Enum.BagIndex.CharacterBankTab_7] = Enum.BagIndex.CharacterBankTab_7,
+    [Enum.BagIndex.Reagentbank] = Enum.BagIndex.Reagentbank,
   }
   const.BANK_ONLY_BAGS = {
     [Enum.BagIndex.CharacterBankTab_1] = Enum.BagIndex.CharacterBankTab_1,
@@ -132,6 +134,8 @@ if addon.isRetail then
     [Enum.BagIndex.CharacterBankTab_4] = Enum.BagIndex.CharacterBankTab_4,
     [Enum.BagIndex.CharacterBankTab_5] = Enum.BagIndex.CharacterBankTab_5,
     [Enum.BagIndex.CharacterBankTab_6] = Enum.BagIndex.CharacterBankTab_6,
+    [Enum.BagIndex.CharacterBankTab_7] = Enum.BagIndex.CharacterBankTab_7,
+    [Enum.BagIndex.Reagentbank] = Enum.BagIndex.Reagentbank,
   }
   const.BANK_ONLY_BAGS_LIST = {
     Enum.BagIndex.CharacterBankTab_1,
@@ -140,6 +144,8 @@ if addon.isRetail then
     Enum.BagIndex.CharacterBankTab_4,
     Enum.BagIndex.CharacterBankTab_5,
     Enum.BagIndex.CharacterBankTab_6,
+    Enum.BagIndex.CharacterBankTab_7,
+    Enum.BagIndex.Reagentbank,
   }
 else
 -- BANK_BAGS contains all the bags that are part of the bank, including
@@ -153,6 +159,7 @@ else
     [Enum.BagIndex.BankBag_5] = Enum.BagIndex.BankBag_5,
     [Enum.BagIndex.BankBag_6] = Enum.BagIndex.BankBag_6,
     [Enum.BagIndex.BankBag_7] = Enum.BagIndex.BankBag_7,
+    [Enum.BagIndex.Reagentbank] = Enum.BagIndex.Reagentbank,
   }
   const.BANK_ONLY_BAGS = {
     [Enum.BagIndex.BankBag_1] = Enum.BagIndex.BankBag_1,
@@ -162,6 +169,7 @@ else
     [Enum.BagIndex.BankBag_5] = Enum.BagIndex.BankBag_5,
     [Enum.BagIndex.BankBag_6] = Enum.BagIndex.BankBag_6,
     [Enum.BagIndex.BankBag_7] = Enum.BagIndex.BankBag_7,
+    [Enum.BagIndex.Reagentbank] = Enum.BagIndex.Reagentbank,
   }
   const.BANK_ONLY_BAGS_LIST = {
     Enum.BagIndex.BankBag_1,
@@ -171,6 +179,7 @@ else
     Enum.BagIndex.BankBag_5,
     Enum.BagIndex.BankBag_6,
     Enum.BagIndex.BankBag_7,
+    Enum.BagIndex.Reagentbank,
   }
 end
 
@@ -181,6 +190,7 @@ if addon.isRetail then
     [Enum.BagIndex.AccountBankTab_3] = Enum.BagIndex.AccountBankTab_3,
     [Enum.BagIndex.AccountBankTab_4] = Enum.BagIndex.AccountBankTab_4,
     [Enum.BagIndex.AccountBankTab_5] = Enum.BagIndex.AccountBankTab_5,
+    [Enum.BagIndex.AccountBankTab_6] = Enum.BagIndex.AccountBankTab_6,
   }
 end
 


### PR DESCRIPTION
## Summary

- **Retail** `BANK_BAGS`, `BANK_ONLY_BAGS`, `BANK_ONLY_BAGS_LIST`: add `CharacterBankTab_7` and `Reagentbank` so the 7th character bank tab and the reagent bank are recognised as purchasable bank slots.
- **Non-retail (Classic/Era)** `BANK_BAGS`, `BANK_ONLY_BAGS`, `BANK_ONLY_BAGS_LIST`: add `Reagentbank` for consistency, treating it as a purchasable slot rather than the main bank container across all game versions.
- `ACCOUNT_BANK_BAGS`: add `AccountBankTab_6` to cover the sixth account bank tab introduced in a recent Retail patch.

Without these entries the new tab and the reagent bank are invisible to bag-type lookups, causing items stored there to be misclassified or not displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)