### PR TITLE
fix: guard unknown bank tab indices to prevent SetItemFromData crash

### DIFF
--- a/core/constants.lua
+++ b/core/constants.lua
@@ -54,6 +54,14 @@ if addon.isRetail then
     [Enum.BagIndex.AccountBankTab_4] = Enum.BagIndex.AccountBankTab_4,
     [Enum.BagIndex.AccountBankTab_5] = Enum.BagIndex.AccountBankTab_5,
   }
+  -- Midnight (12.x) and later may add additional bank tab slots.
+  -- Guard each new enum so the code is a no-op on clients that don't have it.
+  if Enum.BagIndex.CharacterBankTab_7 then
+    const.BANK_TAB[Enum.BagIndex.CharacterBankTab_7] = Enum.BagIndex.CharacterBankTab_7
+  end
+  if Enum.BagIndex.AccountBankTab_6 then
+    const.BANK_TAB[Enum.BagIndex.AccountBankTab_6] = Enum.BagIndex.AccountBankTab_6
+  end
   -- Named aliases used as context markers by UpdateFreeSlots to distinguish
   -- character bank from account bank (warbank) mode. The retail BANK_TAB table
   -- uses integer enum keys only, so these named keys are required for the
@@ -125,6 +133,9 @@ if addon.isRetail then
     [Enum.BagIndex.CharacterBankTab_5] = Enum.BagIndex.CharacterBankTab_5,
     [Enum.BagIndex.CharacterBankTab_6] = Enum.BagIndex.CharacterBankTab_6,
   }
+  if Enum.BagIndex.CharacterBankTab_7 then
+    const.BANK_BAGS[Enum.BagIndex.CharacterBankTab_7] = Enum.BagIndex.CharacterBankTab_7
+  end
   const.BANK_ONLY_BAGS = {
     [Enum.BagIndex.CharacterBankTab_1] = Enum.BagIndex.CharacterBankTab_1,
     [Enum.BagIndex.CharacterBankTab_2] = Enum.BagIndex.CharacterBankTab_2,
@@ -133,6 +144,9 @@ if addon.isRetail then
     [Enum.BagIndex.CharacterBankTab_5] = Enum.BagIndex.CharacterBankTab_5,
     [Enum.BagIndex.CharacterBankTab_6] = Enum.BagIndex.CharacterBankTab_6,
   }
+  if Enum.BagIndex.CharacterBankTab_7 then
+    const.BANK_ONLY_BAGS[Enum.BagIndex.CharacterBankTab_7] = Enum.BagIndex.CharacterBankTab_7
+  end
   const.BANK_ONLY_BAGS_LIST = {
     Enum.BagIndex.CharacterBankTab_1,
     Enum.BagIndex.CharacterBankTab_2,
@@ -141,6 +155,9 @@ if addon.isRetail then
     Enum.BagIndex.CharacterBankTab_5,
     Enum.BagIndex.CharacterBankTab_6,
   }
+  if Enum.BagIndex.CharacterBankTab_7 then
+    table.insert(const.BANK_ONLY_BAGS_LIST, Enum.BagIndex.CharacterBankTab_7)
+  end
 else
 -- BANK_BAGS contains all the bags that are part of the bank, including
 -- the main bank view.
@@ -182,6 +199,9 @@ if addon.isRetail then
     [Enum.BagIndex.AccountBankTab_4] = Enum.BagIndex.AccountBankTab_4,
     [Enum.BagIndex.AccountBankTab_5] = Enum.BagIndex.AccountBankTab_5,
   }
+  if Enum.BagIndex.AccountBankTab_6 then
+    const.ACCOUNT_BANK_BAGS[Enum.BagIndex.AccountBankTab_6] = Enum.BagIndex.AccountBankTab_6
+  end
 end
 
 -- BACKPACK_BAGS contains all the bags that are part of the backpack, including

--- a/data/items.lua
+++ b/data/items.lua
@@ -1595,6 +1595,12 @@ function items:GetBagKindFromBagID(bagid)
 	if const.BANK_BAGS[tonumber(bagid)] or const.ACCOUNT_BANK_BAGS[tonumber(bagid)] then
 		return const.BAG_KIND.BANK
 	end
+	-- Defensive fallback: if the bank slots panel has this bag selected as the
+	-- active Blizzard tab, treat it as a bank bag even if it is not yet in the
+	-- constant tables (e.g. a new bag index added by a WoW patch).
+	if addon.Bags and addon.Bags.Bank and addon.Bags.Bank.blizzardBankTab == tonumber(bagid) then
+		return const.BAG_KIND.BANK
+	end
 	return const.BAG_KIND.BACKPACK
 end
 

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -378,8 +378,8 @@ function BankSlots:CreatePanel(ctx, bagFrame)
   -- this panel has no title, so we match the 12 px bottom gap.
   b.content:GetContainer():SetPoint("TOPLEFT", b.frame, "TOPLEFT", const.OFFSETS.BAG_LEFT_INSET + 4, -12)
   b.content:GetContainer():SetPoint("BOTTOMRIGHT", b.frame, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, 12)
-  -- Allow all 11 slots on one row
-  b.content.maxCellWidth = 11
+  -- Allow all slots on one row (13 max: 7 character + 6 account)
+  b.content.maxCellWidth = 13
   b.content:HideScrollBar()
   -- Bank tab slots grid is not scrollable; disable mouse wheel so scroll
   -- events pass through to the outer scrollable bag container.
@@ -391,8 +391,8 @@ function BankSlots:CreatePanel(ctx, bagFrame)
   b.tabsWereShown = false
 
   -- All possible bank tab slots in order:
-  --   6 character bank tabs (CharacterBankTab_1 through _6)
-  --   5 account/warbank tabs (AccountBankTab_1 through _5)
+  --   6 character bank tabs (CharacterBankTab_1 through _6), plus _7 if present
+  --   5 account/warbank tabs (AccountBankTab_1 through _5), plus _6 if present
   local allTabSlots = {
     {bagIndex = Enum.BagIndex.CharacterBankTab_1, bankType = Enum.BankType.Character},
     {bagIndex = Enum.BagIndex.CharacterBankTab_2, bankType = Enum.BankType.Character},
@@ -406,6 +406,14 @@ function BankSlots:CreatePanel(ctx, bagFrame)
     {bagIndex = Enum.BagIndex.AccountBankTab_4, bankType = Enum.BankType.Account},
     {bagIndex = Enum.BagIndex.AccountBankTab_5, bankType = Enum.BankType.Account},
   }
+  -- New tab slots added in Midnight (12.x) or later patches are inserted after
+  -- their respective last-known tab in order (character before account).
+  if Enum.BagIndex.CharacterBankTab_7 then
+    table.insert(allTabSlots, 7, {bagIndex = Enum.BagIndex.CharacterBankTab_7, bankType = Enum.BankType.Character})
+  end
+  if Enum.BagIndex.AccountBankTab_6 then
+    table.insert(allTabSlots, {bagIndex = Enum.BagIndex.AccountBankTab_6, bankType = Enum.BankType.Account})
+  end
 
   for i, slotInfo in ipairs(allTabSlots) do
     ---@type BankSlotButton

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -323,6 +323,10 @@ end
 function itemFrame.itemProto:SetItem(ctx, slotkey)
 	assert(slotkey, "item must be provided")
 	local data = items:GetItemDataFromSlotKey(slotkey)
+	if not data then
+		debug:Log("SetItem", "No item data found for slotkey", slotkey, "-- bag index may not be registered in constants")
+		return
+	end
 	self:SetItemFromData(ctx, data)
 end
 

--- a/integrations/quickfind.lua
+++ b/integrations/quickfind.lua
@@ -147,13 +147,14 @@ function quickfind:ShowInBag(id)
         if bag.behavior.SwitchToBank then
           bag.behavior:SwitchToBank(ctx)
         end
-      elseif tabID >= Enum.BagIndex.CharacterBankTab_1 and tabID <= Enum.BagIndex.CharacterBankTab_6 then
-        -- Character bank tabs (6-11)
+      elseif addon.isRetail and Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.AccountBankTab_1
+          and tabID >= Enum.BagIndex.CharacterBankTab_1 and tabID < Enum.BagIndex.AccountBankTab_1 then
+        -- Character bank tabs (6 through AccountBankTab_1-1, handles future tabs)
         if bag.behavior.SwitchToCharacterBankTab then
           bag.behavior:SwitchToCharacterBankTab(ctx, tabID)
         end
-      elseif tabID >= Enum.BagIndex.AccountBankTab_1 and tabID <= Enum.BagIndex.AccountBankTab_5 then
-        -- Account bank tabs (13-17)
+      elseif addon.isRetail and Enum.BagIndex.AccountBankTab_1 and tabID >= Enum.BagIndex.AccountBankTab_1 then
+        -- Account bank tabs (13+, handles future tabs)
         if bag.behavior.SwitchToAccountBank then
           bag.behavior:SwitchToAccountBank(ctx, tabID)
         end

--- a/themes/themes.lua
+++ b/themes/themes.lua
@@ -488,7 +488,7 @@ function themes.SetupBagButton(bag, decoration)
       end
     elseif e == "RightButton" then
       if bag.kind == const.BAG_KIND.BANK and addon.isRetail then
-        if bag.bankTab <= Enum.BagIndex.CharacterBankTab_6 then
+        if bag.bankTab < Enum.BagIndex.AccountBankTab_1 then
           C_Bank.AutoDepositItemsIntoBank(Enum.BankType.Character)
           C_Container.SortBankBags()
         else


### PR DESCRIPTION
## Summary

Fixes a crash (`data must be provided` at `frames/item.lua:376`) that occurs when WoW patches introduce new bank tab bag indices not yet registered in the addon's constant tables.

- **`core/constants.lua`**: Conditionally register `CharacterBankTab_7` and `AccountBankTab_6` into all relevant constant tables (`BANK_TAB`, `BANK_BAGS`, `BANK_ONLY_BAGS`, `BANK_ONLY_BAGS_LIST`, `ACCOUNT_BANK_BAGS`) using `if Enum.BagIndex.X then` guards, making the addon forward-compatible with Midnight (12.x) patches.
- **`frames/item.lua`**: Add a nil guard in `SetItem` — log and return early when `GetItemDataFromSlotKey` returns `nil` instead of asserting into `SetItemFromData` with a nil data table.
- **`frames/bankslots.lua`**: Raise `maxCellWidth` from 11 → 13 to accommodate new slots; insert `CharacterBankTab_7` and `AccountBankTab_6` into `allTabSlots` in positional order when the enums exist on the client.
- **`data/items.lua`**: Add a defensive fallback in `GetBagKindFromBagID` so a bag matching the active Blizzard bank tab is classified as `BANK` even if its index is absent from the constant tables.
- **`integrations/quickfind.lua`**: Guard both bank-tab range comparisons with `addon.isRetail` **and** nil checks for the base enum values, preventing `number >= nil` errors on Classic. Account tab detection now uses an open-ended upper bound (`>= AccountBankTab_1`) to handle future tabs.
- **`themes/themes.lua`**: Replace hard-coded `<= CharacterBankTab_6` in the right-click auto-deposit path with `< AccountBankTab_1` so the correct deposit type is chosen when additional character bank tabs exist.

## Test plan

- [ ] Verify no `data must be provided` errors appear in Retail with the current patch
- [ ] Confirm bank tab UI renders correctly in Retail (character and account tabs)
- [ ] Confirm Classic/Era loads without errors (nil enum guard in quickfind)
- [ ] Right-click auto-deposit on character bank items deposits to character bank
- [ ] Right-click auto-deposit on account/warbank items deposits to account bank

🤖 Generated with [Claude Code](https://claude.com/claude-code)