### PR TITLE
chore: remove stale context file reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,5 @@
 # Claude
 
-@.context/wow-addon-architect.md
 @.context/api.md
 @.context/documentation.md
 @.context/patterns.md


### PR DESCRIPTION
## Summary

- Removed the `@.context/wow-addon-architect.md` line from `CLAUDE.md` — this file no longer exists on disk and was causing ENOENT errors when the context was loaded.
- All remaining `@.context/` references in `CLAUDE.md` point to valid files and are unaffected.

## Why

The stale reference produced file-not-found errors during context loading. No functionality is lost since the file it pointed to no longer exists.