### PR TITLE
fix: nil-guard stale slotkeys in deferred draw pipeline

### DIFF
--- a/frames/item.lua
+++ b/frames/item.lua
@@ -323,6 +323,13 @@ end
 function itemFrame.itemProto:SetItem(ctx, slotkey)
 	assert(slotkey, "item must be provided")
 	local data = items:GetItemDataFromSlotKey(slotkey)
+	if not data then
+		-- Item data can be nil when the global slotInfo was replaced by WipeSlotInfo
+		-- between when the draw was queued (via SendMessageLater) and when it fires.
+		-- Silently skip stale slotkeys rather than crashing.
+		debug:Log("SetItem", "No item data for slotkey", slotkey, "- skipping stale draw")
+		return
+	end
 	self:SetItemFromData(ctx, data)
 end
 


### PR DESCRIPTION
## What changed

Guards `GetItemDataFromSlotKey` return values at every call site in the async draw pipeline to prevent the `"data must be provided"` crash in `SetItemFromData`.

## Why it crashed

`events:SendMessageLater` defers bag draws by one frame via `C_Timer.After(0)`. Between when the changeset is built and when the draw fires, a concurrent `BAG_UPDATE_DELAYED` or `wipe=true` refresh can call `WipeSlotInfo`, replacing the live `SlotInfo` object with a fresh empty one. Slotkeys from the now-orphaned previous changeset then return `nil` from `GetItemDataFromSlotKey`, causing the crash.

## Fix

Nil-checks added at four call sites:
- **`frames/item.lua` `SetItem`** — return early and log if `data` is nil
- **`views/gridview.lua` `CreateButton`** — return `false` if `item` is nil
- **`views/gridview.lua` `ClearButton`** — skip `drawOnClose` assignment if `item` is nil  
- **`views/gridview.lua` `ReconcileWithPartial`** — return if `rootItem` is nil; nil-check `childData` before comparing `itemStackCount` fields

The race condition is documented in `.context/patterns-state.md` for future reference.