### PR TITLE
feat: add Zygor Guides upgrade icon integration

### DIFF
--- a/BetterBags.toc
+++ b/BetterBags.toc
@@ -10,7 +10,7 @@
 ## X-License: MIT
 ## X-Curse-Project-ID: 942432
 ## X-Wago-ID: aNDmy96o
-## OptionalDeps: LibStub, Masque, CallbackHandler-1.0, Ace3, LibSharedMedia-3.0, _DebugLog, ConsolePort, Pawn, WagoAnalytics, GW2_UI, ElvUI, DevTool
+## OptionalDeps: LibStub, Masque, CallbackHandler-1.0, Ace3, LibSharedMedia-3.0, _DebugLog, ConsolePort, Pawn, ZygorGuidesViewer, WagoAnalytics, GW2_UI, ElvUI, DevTool
 
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
@@ -130,6 +130,7 @@ config\plugin.lua
 
 integrations\consoleport.lua
 integrations\pawn.lua
+integrations\zygor.lua
 integrations\masque.lua
 integrations\simpleitemlevel.lua
 integrations\quickfind.lua

--- a/config/config.lua
+++ b/config/config.lua
@@ -138,7 +138,7 @@ function config:CreateConfig()
   f:AddDropdown({
     title = 'Upgrade Icon Provider',
     description = 'Select the icon provider for item upgrades.',
-    items = {'None', 'BetterBags'},
+    items = {'None', 'BetterBags', 'Zygor'},
     getValue = function(_, value)
       return value == db:GetUpgradeIconProvider()
     end,

--- a/integrations/zygor.lua
+++ b/integrations/zygor.lua
@@ -1,0 +1,52 @@
+local addonName = ... ---@type string
+
+---@class BetterBags: AceAddon
+local addon = LibStub('AceAddon-3.0'):GetAddon(addonName)
+
+---@class Events: AceModule
+local events = addon:GetModule('Events')
+
+---@class Items: AceModule
+local items = addon:GetModule('Items')
+
+---@class Database: AceModule
+local database = addon:GetModule('Database')
+
+---@class Zygor: AceModule
+local zygor = addon:NewModule('Zygor')
+
+---@param item Item
+local function onItemUpdate(item)
+  if not item.button.UpgradeIcon then return end
+  local data = item:GetItemData()
+  if not data then return end
+  if data.isItemEmpty or not data.bagid or not data.slotid then
+    item.button.UpgradeIcon:SetShown(false)
+    return
+  end
+  local isUpgrade, _, _, _, comment = ZGV.ItemScore.Upgrades:IsUpgrade(data.itemInfo.itemLink)
+  if comment == "not scored" or comment == "no link" then return end
+  item.button.UpgradeIcon:SetShown(isUpgrade or false)
+end
+
+---@param bag Bag
+local function onBagRendered(_, bag, _)
+  if InCombatLockdown() then
+    addon.Bags.Backpack.drawAfterCombat = true
+    return
+  end
+  if database:GetUpgradeIconProvider() ~= 'Zygor' then return end
+  if not ZGV.ItemScore.ActiveRuleSet then return end
+  items:PreLoadAllEquipmentSlots(function()
+    for _, item in pairs(bag.currentView:GetItemsByBagAndSlot()) do
+      onItemUpdate(item)
+    end
+  end)
+end
+
+function zygor:OnEnable()
+  if not ZGV or not ZGV.ItemScore or not ZGV.ItemScore.Upgrades then
+    return
+  end
+  events:RegisterMessage('bag/Rendered', onBagRendered)
+end


### PR DESCRIPTION
## Summary

- Adds `integrations/zygor.lua` following the existing Pawn integration pattern
- When Zygor Guides is installed with an active item scoring rule set, its stat-weight-based `IsUpgrade` check drives the bag upgrade arrow instead of BetterBags' built-in item level comparison
- Adds `ZygorGuidesViewer` to `OptionalDeps` in `BetterBags.toc`

## How It Works

- Registers on `bag/Rendered` and iterates items (same as Pawn integration)
- Calls `ZGV.ItemScore.Upgrades:IsUpgrade(itemLink)` for each equippable item
- Skips items Zygor can't score (`"not scored"` / `"no link"` comments) — falls through to default behavior
- Checks `ActiveRuleSet` at render time so it responds to mid-session profile/spec changes
- Gracefully no-ops if Zygor is not installed

## Files Changed

- `integrations/zygor.lua` — new file (48 lines)
- `BetterBags.toc` — added `ZygorGuidesViewer` to `OptionalDeps`, added `integrations\zygor.lua` after pawn

## Test Plan

- [ ] Install with Zygor Guides active — verify upgrade arrows use stat-weight scoring
- [ ] Verify items Zygor marks as downgrades don't show the green arrow (even if higher ilvl)
- [ ] Test without Zygor installed — verify no errors and default BetterBags behavior works
- [ ] Switch specs mid-session — verify arrows update on next bag open

🤖 Generated with [Claude Code](https://claude.com/claude-code)