### PR TITLE
feat: detect PatchWerk conflict and show undismissable disable prompt

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -117,7 +117,14 @@ Main initialization module that coordinates addon startup.
 - Creates main bag instances (Backpack and Bank)
 - Initializes all submodules in correct order
 - Registers core event handlers
-- Manages compatibility with other addons
+- Manages compatibility with other addons via `applyCompat()`
+
+#### Addon Compatibility Checks (`applyCompat`)
+
+`applyCompat()` runs deferred checks for known conflicting addons:
+
+- **BetterBagsElvUISkin** (5s delay): Detected via `C_AddOns.IsAddOnLoaded`; disabled via `C_AddOns.DisableAddOn` and an alert shown via `question:Alert`.
+- **PatchWerk** (2s delay): Detected via `C_AddOns.IsAddOnLoaded("PatchWerk")`; shows an undismissable `StaticPopupDialogs` popup (`hideOnEscape = false`, no cancel button). The single "Disable & Reload" button calls `C_AddOns.DisableAddOn("PatchWerk")` then `ReloadUI()`. PatchWerk globally patches WoW functions in a way that breaks all addons, so the user must disable it entirely.
 
 ### localization.lua
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -248,6 +248,26 @@ local function applyCompat()
       C_AddOns.DisableAddOn("BetterBagsElvUISkin")
     end
   end)
+
+  -- PatchWerk breaks every WoW addon by patching functions globally, even addons
+  -- it is not configured to patch. Detect it early and force the user to disable it.
+  C_Timer.After(2, function()
+    if C_AddOns.IsAddOnLoaded("PatchWerk") then
+      StaticPopupDialogs["BETTERBAGS_PATCHWERK_CONFLICT"] = {
+        text = "BetterBags has detected that the addon |cFFFF4400PatchWerk|r is loaded.\n\nPatchWerk breaks every WoW addon, even addons it is not configured to patch. You must disable PatchWerk entirely for BetterBags and other addons to work correctly.\n\nClick 'Disable & Reload' to disable PatchWerk and reload your UI.",
+        button1 = "Disable & Reload",
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = false,
+        preferredIndex = 3,
+        OnAccept = function()
+          C_AddOns.DisableAddOn("PatchWerk")
+          ReloadUI()
+        end,
+      }
+      StaticPopup_Show("BETTERBAGS_PATCHWERK_CONFLICT")
+    end
+  end)
 end
 
 -- OnEnable is called when the addon is enabled.


### PR DESCRIPTION
## Summary
PatchWerk is an addon that globally patches WoW API functions in a way that breaks all addons, even those it is not configured to patch. This PR adds a deferred compatibility check in `applyCompat()` that detects if PatchWerk is loaded and forces the user to disable it before continuing.

The check uses `C_Timer.After(2, ...)` to allow for delayed addon loading, then shows an undismissable `StaticPopupDialogs` popup if PatchWerk is detected. The only option is a "Disable & Reload" button that calls `C_AddOns.DisableAddOn("PatchWerk")` and `ReloadUI()`.

## Changes
- Added a `C_Timer.After(2, ...)` block inside `applyCompat()` in `core/init.lua` that checks `C_AddOns.IsAddOnLoaded("PatchWerk")`
- Registered `StaticPopupDialogs["BETTERBAGS_PATCHWERK_CONFLICT"]` with `hideOnEscape = false`, no cancel button, and `timeout = 0` so it cannot be dismissed
- The single "Disable & Reload" button calls `C_AddOns.DisableAddOn("PatchWerk")` then `ReloadUI()`
- Updated `core/README.md` to document the `applyCompat()` pattern and both compat checks (ElvUI skin and PatchWerk)

## Notes
The 2-second delay mirrors the existing ElvUI skin check pattern (5s) but is shorter since PatchWerk's damage is immediate and we want to surface the warning as early as possible. `applyCompat()` is shared across all WoW versions (Retail, Classic Era) so the check applies everywhere. All globals used (`StaticPopupDialogs`, `StaticPopup_Show`, `C_AddOns`, `ReloadUI`) are already declared in `.luacheckrc` — luacheck passes with 0 warnings.