### PR TITLE
test: add coverage for equipmentsets, resize, database, refresh + fix two bugs

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -225,6 +225,10 @@ files["spec/**/*.lua"] = {
 	globals = {
 		"LoadBetterBagsModule",
 		"StubBetterBagsModule",
+		"ResetModuleStub",
 		"MockData",
+	},
+	ignore = {
+		"212", -- unused argument (common in mock functions)
 	},
 }

--- a/core/database.lua
+++ b/core/database.lua
@@ -1018,7 +1018,7 @@ function DB:Migrate()
       if DB.data.profile.size[bagView] then
         local t = DB.data.profile.size[bagView][bagKind]
         if t then
-          if t.itemsPerRow ~= nil and t.itemsPerRow > 30 or t.itemsPerRow < 1 then
+          if t.itemsPerRow and (t.itemsPerRow > 30 or t.itemsPerRow < 1) then
             t.itemsPerRow = 7
           end
         end

--- a/data/refresh.lua
+++ b/data/refresh.lua
@@ -89,6 +89,11 @@ function refresh:RequestUpdate(request)
   -- Handle sorting immediately
   if request.sort and not InCombatLockdown() then
     self.isSorting = true
+    -- Cancel any pending debounce timer before starting sort
+    if self.debounceTimer then
+      self.debounceTimer:Cancel()
+      self.debounceTimer = nil
+    end
     items:RemoveNewItemFromAllItems()
     local ctx = context:New('BagSort')
     items:Restack(ctx, const.BAG_KIND.BACKPACK, function()

--- a/spec/database_migration_spec.lua
+++ b/spec/database_migration_spec.lua
@@ -1,0 +1,200 @@
+-- database_migration_spec.lua -- Tests targeting the Migrate() function directly.
+-- This file does NOT stub Migrate() so we can test real migration logic.
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+addon.isRetail = true
+addon.isClassic = false
+addon.isBCC = false
+addon.isCata = false
+addon.isMists = false
+addon.isAnniversary = false
+addon.isMidnight = false
+addon.tocVersion = 110000
+
+-- Required globals
+_G.Enum = _G.Enum or {}
+_G.Enum.BankType = { Character = 1, Account = 2 }
+_G.Enum.BagIndex = {
+  Backpack = 0, Bag_1 = 1, Bag_2 = 2, Bag_3 = 3, Bag_4 = 4,
+  ReagentBag = 5, Bank = -1, Reagentbank = -3,
+  BankBag_1 = 6, BankBag_2 = 7, BankBag_3 = 8, BankBag_4 = 9,
+  BankBag_5 = 10, BankBag_6 = 11, BankBag_7 = 12,
+  Characterbanktab = 100, CharacterBankTab_1 = 101, CharacterBankTab_2 = 102,
+  CharacterBankTab_3 = 103, CharacterBankTab_4 = 104, CharacterBankTab_5 = 105,
+  CharacterBankTab_6 = 106,
+  AccountBankTab_1 = 200, AccountBankTab_2 = 201, AccountBankTab_3 = 202,
+  AccountBankTab_4 = 203, AccountBankTab_5 = 204,
+}
+_G.Enum.ItemQuality = {
+  Poor = 0, Common = 1, Uncommon = 2, Rare = 3, Epic = 4,
+  Legendary = 5, Artifact = 6, Heirloom = 7, WoWToken = 8,
+  Good = 2, Standard = 1,
+}
+_G.Enum.ItemClass = { Tradegoods = 7 }
+_G.Enum.InventoryType = {
+  IndexHeadType = 1, IndexNeckType = 2, IndexShoulderType = 3,
+  IndexBodyType = 4, IndexChestType = 5, IndexWaistType = 6,
+  IndexLegsType = 7, IndexFeetType = 8, IndexWristType = 9,
+  IndexHandType = 10, IndexFingerType = 11, IndexTrinketType = 12,
+  IndexWeaponType = 13, IndexShieldType = 14, IndexRangedType = 15,
+  IndexCloakType = 16, Index2HweaponType = 17, IndexTabardType = 18,
+  IndexRobeType = 20, IndexWeaponmainhandType = 21,
+  IndexWeaponoffhandType = 22, IndexHoldableType = 23,
+  IndexThrownType = 25, IndexRangedrightType = 26,
+}
+
+_G.C_Item = _G.C_Item or {}
+if not _G.C_Item.GetItemSubClassInfo then
+  _G.C_Item.GetItemSubClassInfo = function() return "MockSubClass" end
+end
+
+-- Dependencies
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("util/serialization.lua")
+
+addon:GetModule("Context")
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+debug.Inspect = function() end
+
+local L = StubBetterBagsModule("Localization")
+L.data = {}
+L.locale = "enUS"
+function L:G(key) return key end
+
+-- Set up Constants
+local const = StubBetterBagsModule("Constants")
+const.BAG_KIND = { BACKPACK = 0, BANK = 1, UNDEFINED = -1 }
+const.BAG_VIEW = { UNDEFINED = 0, ONE_BAG = 1, SECTION_GRID = 2, LIST = 3, SECTION_ALL_BAGS = 4 }
+const.SECTION_SORT_TYPE = { ALPHABETICALLY = 1, SIZE_DESCENDING = 2, SIZE_ASCENDING = 3 }
+const.ITEM_SORT_TYPE = { ALPHABETICALLY_THEN_QUALITY = 1, QUALITY_THEN_ALPHABETICALLY = 2, ITEM_LEVEL = 3, EXPANSION = 4 }
+const.GRID_COMPACT_STYLE = { NONE = 0, SIMPLE = 1, COMPACT = 2 }
+const.SEARCH_CATEGORY_GROUP_BY = { NONE = 0, TYPE = 1, SUBTYPE = 2, EXPANSION = 3 }
+const.FORM_LAYOUT = { TWO_COLUMN = 1, STACKED = 2 }
+const.BINDING_SCOPE = {}
+const.BINDING_MAP = {}
+
+-- Minimal defaults (same as database_spec.lua)
+const.DATABASE_DEFAULTS = {
+  profile = {
+    firstTimeMenu = true, enabled = true, enableBagFading = false,
+    showBagButton = true, enableBankBag = true, showBankTabs = false,
+    debug = false, inBagSearch = true, categorySell = false,
+    showKeybindWarning = true, enterToMakeCategory = true,
+    upgradeIconProvider = 'None', theme = 'Default',
+    showFullSectionNames = { [0] = false, [1] = false },
+    showAllFreeSpace = { [0] = false, [1] = false },
+    extraGlowyButtons = { [0] = false, [1] = false },
+    newItems = {
+      [0] = { markRecentItems = true, showNewItemFlash = false },
+      [1] = { markRecentItems = true, showNewItemFlash = false },
+    },
+    stacking = {
+      [0] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+      [1] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+    },
+    itemLevel = {
+      [0] = { enabled = true, color = true },
+      [1] = { enabled = true, color = true },
+    },
+    itemLevelColor = {
+      maxItemLevelByCharacter = {},
+      colors = {
+        low = { red = 0.62, green = 0.62, blue = 0.62, alpha = 1 },
+        mid = { red = 1, green = 1, blue = 1, alpha = 1 },
+        high = { red = 0, green = 0.55, blue = 0.87, alpha = 1 },
+        max = { red = 1, green = 0.5, blue = 0, alpha = 1 },
+      }
+    },
+    positions = { [0] = {}, [1] = {} },
+    anchorPositions = { [0] = {}, [1] = {} },
+    anchorState = { [0] = { enabled = false, shown = false }, [1] = { enabled = false, shown = false } },
+    sectionSort = { [0] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 }, [1] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 } },
+    itemSort = { [0] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 }, [1] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 } },
+    customSectionSort = { [0] = {}, [1] = {} },
+    collapsedSections = { [0] = {}, [1] = {} },
+    size = {
+      [1] = {
+        [0] = { columnCount = 15, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [2] = {
+        [0] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [3] = {
+        [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 5, itemsPerRow = 5, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [4] = {
+        [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+    },
+    views = { [0] = 2, [1] = 2 },
+    previousViews = { [0] = 2, [1] = 2 },
+    categoryOptions = {}, customCategoryFilters = {}, ephemeralCategoryFilters = {}, customCategoryIndex = {},
+    categoryFilters = {
+      [0] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+      [1] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+    },
+    lockedItems = {},
+    newItemTime = 300,
+    groups = { [0] = { [1] = { id = 1, name = "Backpack", order = 1, kind = 0, isDefault = true } }, [1] = {} },
+    groupCounter = { [0] = 1, [1] = 0 },
+    categoryToGroup = { [0] = {}, [1] = {} },
+    activeGroup = { [0] = 1, [1] = 1 },
+    groupsEnabled = { [0] = true, [1] = true },
+    __profileSystemMigrated = false,
+  },
+  char = {},
+}
+
+-- IMPORTANT: do NOT stub Migrate — we're testing it
+ResetModuleStub("Database", "core/database.lua")
+LoadBetterBagsModule("core/database.lua")
+local DB = addon:GetModule("Database")
+
+-- Initialize — Migrate() runs inside OnInitialize with valid defaults
+DB:OnInitialize()
+
+describe("Database Migration", function()
+
+  -- ─── Bug: nil itemsPerRow crashes Migrate() ────────────────────────────────────
+
+  describe("size fix migration (line 1021)", function()
+
+    it("handles nil itemsPerRow gracefully (no crash)", function()
+      DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BACKPACK].itemsPerRow = nil
+
+      -- With the fix: (nil and ...) → short-circuits to nil (falsy), no crash
+      DB:Migrate()
+      -- nil itemsPerRow is left alone; AceDB defaults will fill it from DATABASE_DEFAULTS
+      assert.is_nil(DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BACKPACK].itemsPerRow)
+    end)
+
+    it("handles itemsPerRow = 0 correctly (not affected by the bug)", function()
+      DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BACKPACK].itemsPerRow = 0
+      -- 0 < 1 is true, so it should be fixed to 7 without error
+      DB:Migrate()
+      assert.are.equal(7, DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BACKPACK].itemsPerRow)
+    end)
+
+    it("handles itemsPerRow = 35 correctly", function()
+      DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BANK].itemsPerRow = 35
+      DB:Migrate()
+      assert.are.equal(7, DB.data.profile.size[const.BAG_VIEW.SECTION_GRID][const.BAG_KIND.BANK].itemsPerRow)
+    end)
+
+    it("leaves valid itemsPerRow alone", function()
+      local original = DB.data.profile.size[const.BAG_VIEW.LIST][const.BAG_KIND.BACKPACK].itemsPerRow
+      DB:Migrate()
+      assert.are.equal(original, DB.data.profile.size[const.BAG_VIEW.LIST][const.BAG_KIND.BACKPACK].itemsPerRow)
+    end)
+  end)
+end)

--- a/spec/database_spec.lua
+++ b/spec/database_spec.lua
@@ -1,0 +1,1197 @@
+-- database_spec.lua -- Unit tests for core/database.lua
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Set up version flags
+addon.isRetail = true
+addon.isClassic = false
+addon.isBCC = false
+addon.isCata = false
+addon.isMists = false
+addon.isAnniversary = false
+addon.isMidnight = false
+addon.tocVersion = 110000
+
+-- Required globals for database defaults and migration
+_G.Enum = _G.Enum or {}
+_G.Enum.BankType = { Character = 1, Account = 2 }
+_G.Enum.BagIndex = {
+  Backpack = 0, Bag_1 = 1, Bag_2 = 2, Bag_3 = 3, Bag_4 = 4,
+  ReagentBag = 5, Bank = -1, Reagentbank = -3,
+  BankBag_1 = 6, BankBag_2 = 7, BankBag_3 = 8, BankBag_4 = 9,
+  BankBag_5 = 10, BankBag_6 = 11, BankBag_7 = 12,
+  Characterbanktab = 100, CharacterBankTab_1 = 101, CharacterBankTab_2 = 102,
+  CharacterBankTab_3 = 103, CharacterBankTab_4 = 104, CharacterBankTab_5 = 105,
+  CharacterBankTab_6 = 106,
+  AccountBankTab_1 = 200, AccountBankTab_2 = 201, AccountBankTab_3 = 202,
+  AccountBankTab_4 = 203, AccountBankTab_5 = 204,
+}
+_G.Enum.ItemQuality = {
+  Poor = 0, Common = 1, Uncommon = 2, Rare = 3, Epic = 4,
+  Legendary = 5, Artifact = 6, Heirloom = 7, WoWToken = 8,
+  Good = 2, Standard = 1,
+}
+_G.Enum.ItemClass = { Tradegoods = 7 }
+_G.Enum.InventoryType = {
+  IndexHeadType = 1, IndexNeckType = 2, IndexShoulderType = 3,
+  IndexBodyType = 4, IndexChestType = 5, IndexWaistType = 6,
+  IndexLegsType = 7, IndexFeetType = 8, IndexWristType = 9,
+  IndexHandType = 10, IndexFingerType = 11, IndexTrinketType = 12,
+  IndexWeaponType = 13, IndexShieldType = 14, IndexRangedType = 15,
+  IndexCloakType = 16, Index2HweaponType = 17, IndexTabardType = 18,
+  IndexRobeType = 20, IndexWeaponmainhandType = 21,
+  IndexWeaponoffhandType = 22, IndexHoldableType = 23,
+  IndexThrownType = 25, IndexRangedrightType = 26,
+}
+
+-- C_Item mock for TRADESKILL_MAP
+_G.C_Item = _G.C_Item or {}
+if not _G.C_Item.GetItemSubClassInfo then
+  _G.C_Item.GetItemSubClassInfo = function() return "MockSubClass" end
+end
+
+-- Dependencies
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("util/serialization.lua")
+
+addon:GetModule("Context")
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+StubBetterBagsModule("Debug")
+local debug = addon:GetModule("Debug")
+debug.Log = function() end
+debug.Inspect = function() end
+
+local L = StubBetterBagsModule("Localization")
+L.data = {}
+L.locale = "enUS"
+function L:G(key) return key end
+
+-- Set up Constants module
+local const = StubBetterBagsModule("Constants")
+const.BAG_KIND = { BACKPACK = 0, BANK = 1, UNDEFINED = -1 }
+const.BAG_VIEW = { UNDEFINED = 0, ONE_BAG = 1, SECTION_GRID = 2, LIST = 3, SECTION_ALL_BAGS = 4 }
+const.SECTION_SORT_TYPE = { ALPHABETICALLY = 1, SIZE_DESCENDING = 2, SIZE_ASCENDING = 3 }
+const.ITEM_SORT_TYPE = { ALPHABETICALLY_THEN_QUALITY = 1, QUALITY_THEN_ALPHABETICALLY = 2, ITEM_LEVEL = 3, EXPANSION = 4 }
+const.GRID_COMPACT_STYLE = { NONE = 0, SIMPLE = 1, COMPACT = 2 }
+const.SEARCH_CATEGORY_GROUP_BY = { NONE = 0, TYPE = 1, SUBTYPE = 2, EXPANSION = 3 }
+const.FORM_LAYOUT = { TWO_COLUMN = 1, STACKED = 2 }
+const.BINDING_SCOPE = {}
+const.BINDING_MAP = {}
+
+-- Minimal DATABASE_DEFAULTS
+const.DATABASE_DEFAULTS = {
+  profile = {
+    firstTimeMenu = true,
+    enabled = true,
+    enableBagFading = false,
+    showBagButton = true,
+    enableBankBag = true,
+    showBankTabs = false,
+    debug = false,
+    inBagSearch = true,
+    categorySell = false,
+    showKeybindWarning = true,
+    enterToMakeCategory = true,
+    upgradeIconProvider = 'None',
+    theme = 'Default',
+    showFullSectionNames = { [0] = false, [1] = false },
+    showAllFreeSpace = { [0] = false, [1] = false },
+    extraGlowyButtons = { [0] = false, [1] = false },
+    newItems = {
+      [0] = { markRecentItems = true, showNewItemFlash = false },
+      [1] = { markRecentItems = true, showNewItemFlash = false },
+    },
+    stacking = {
+      [0] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+      [1] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+    },
+    itemLevel = {
+      [0] = { enabled = true, color = true },
+      [1] = { enabled = true, color = true },
+    },
+    itemLevelColor = {
+      maxItemLevelByCharacter = {},
+      colors = {
+        low = { red = 0.62, green = 0.62, blue = 0.62, alpha = 1 },
+        mid = { red = 1, green = 1, blue = 1, alpha = 1 },
+        high = { red = 0, green = 0.55, blue = 0.87, alpha = 1 },
+        max = { red = 1, green = 0.5, blue = 0, alpha = 1 },
+      }
+    },
+    positions = { [0] = {}, [1] = {} },
+    anchorPositions = { [0] = {}, [1] = {} },
+    anchorState = {
+      [0] = { enabled = false, shown = false },
+      [1] = { enabled = false, shown = false },
+    },
+    sectionSort = {
+      [0] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 },
+      [1] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 },
+    },
+    itemSort = {
+      [0] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 },
+      [1] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 },
+    },
+    customSectionSort = { [0] = {}, [1] = {} },
+    collapsedSections = { [0] = {}, [1] = {} },
+    size = {
+      [1] = {
+        [0] = { columnCount = 15, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [2] = {
+        [0] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [3] = {
+        [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 5, itemsPerRow = 5, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+      [4] = {
+        [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+        [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+      },
+    },
+    views = { [0] = 2, [1] = 2 },
+    previousViews = { [0] = 2, [1] = 2 },
+    categoryOptions = {},
+    customCategoryFilters = {},
+    ephemeralCategoryFilters = {},
+    customCategoryIndex = {},
+    categoryFilters = {
+      [0] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+      [1] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+    },
+    lockedItems = {},
+    newItemTime = 300,
+    groups = {
+      [0] = { [1] = { id = 1, name = "Backpack", order = 1, kind = 0, isDefault = true } },
+      [1] = {},
+    },
+    groupCounter = { [0] = 1, [1] = 0 },
+    categoryToGroup = { [0] = {}, [1] = {} },
+    activeGroup = { [0] = 1, [1] = 1 },
+    groupsEnabled = { [0] = true, [1] = true },
+    __profileSystemMigrated = false,
+  },
+  char = {},
+}
+
+-- Un-stub Database if it was previously stubbed by another spec (e.g. categories_spec)
+ResetModuleStub("Database", "core/database.lua")
+
+LoadBetterBagsModule("core/database.lua")
+local DB = addon:GetModule("Database")
+
+-- Stub Migrate to simplify test setup (we test migration behavior separately)
+DB.Migrate = function() end
+
+-- Initialize the database with our controlled defaults
+DB:OnInitialize()
+
+describe("Database", function()
+
+  before_each(function()
+    -- Get a fresh profile by resetting
+    DB.data:ResetProfile(false, true)
+    -- Set up known state for tests
+    DB.data.profile.firstTimeMenu = false
+  end)
+
+  -- ─── Basic getters/setters ─────────────────────────────────────────────────────
+
+  describe("basic booleans", function()
+
+    it("GetShowBagButton / SetShowBagButton", function()
+      DB:SetShowBagButton(false)
+      assert.is_false(DB:GetShowBagButton())
+      DB:SetShowBagButton(true)
+      assert.is_true(DB:GetShowBagButton())
+    end)
+
+    it("GetEnableBankBag / SetEnableBankBag", function()
+      DB:SetEnableBankBag(false)
+      assert.is_false(DB:GetEnableBankBag())
+    end)
+
+    it("GetShowBankTabs / SetShowBankTabs", function()
+      DB:SetShowBankTabs(true)
+      assert.is_true(DB:GetShowBankTabs())
+    end)
+
+    it("GetEnableBagFading / SetEnableBagFading", function()
+      DB:SetEnableBagFading(true)
+      assert.is_true(DB:GetEnableBagFading())
+    end)
+
+    it("GetDebugMode / SetDebugMode", function()
+      DB:SetDebugMode(true)
+      assert.is_true(DB:GetDebugMode())
+    end)
+
+    it("GetInBagSearch / SetInBagSearch", function()
+      DB:SetInBagSearch(false)
+      assert.is_false(DB:GetInBagSearch())
+    end)
+
+    it("GetCategorySell / SetCategorySell", function()
+      DB:SetCategorySell(true)
+      assert.is_true(DB:GetCategorySell())
+    end)
+
+    it("GetShowKeybindWarning / SetShowKeybindWarning", function()
+      DB:SetShowKeybindWarning(false)
+      assert.is_false(DB:GetShowKeybindWarning())
+    end)
+
+    it("GetEnterToMakeCategory / SetEnterToMakeCategory", function()
+      DB:SetEnterToMakeCategory(false)
+      assert.is_false(DB:GetEnterToMakeCategory())
+    end)
+  end)
+
+  -- ─── Bag view ──────────────────────────────────────────────────────────────────
+
+  describe("bag views", function()
+
+    it("GetBagView returns the configured view", function()
+      assert.are.equal(const.BAG_VIEW.SECTION_GRID, DB:GetBagView(const.BAG_KIND.BACKPACK))
+    end)
+
+    it("SetBagView changes the view", function()
+      DB:SetBagView(const.BAG_KIND.BACKPACK, const.BAG_VIEW.LIST)
+      assert.are.equal(const.BAG_VIEW.LIST, DB:GetBagView(const.BAG_KIND.BACKPACK))
+    end)
+
+    it("GetPreviousView / SetPreviousView", function()
+      DB:SetPreviousView(const.BAG_KIND.BANK, const.BAG_VIEW.ONE_BAG)
+      assert.are.equal(const.BAG_VIEW.ONE_BAG, DB:GetPreviousView(const.BAG_KIND.BANK))
+    end)
+  end)
+
+  -- ─── New items ─────────────────────────────────────────────────────────────────
+
+  describe("new items", function()
+
+    it("GetMarkRecentItems / SetMarkRecentItems", function()
+      DB:SetMarkRecentItems(const.BAG_KIND.BACKPACK, false)
+      assert.is_false(DB:GetMarkRecentItems(const.BAG_KIND.BACKPACK))
+    end)
+
+    it("GetShowNewItemFlash / SetShowNewItemFlash", function()
+      DB:SetShowNewItemFlash(const.BAG_KIND.BANK, true)
+      assert.is_true(DB:GetShowNewItemFlash(const.BAG_KIND.BANK))
+    end)
+
+    it("GetNewItemTime / SetNewItemTime", function()
+      DB:SetNewItemTime(600)
+      assert.are.equal(600, DB:GetNewItemTime())
+    end)
+  end)
+
+  -- ─── Groups enabled ────────────────────────────────────────────────────────────
+
+  describe("groups enabled", function()
+
+    it("GetGroupsEnabled returns true by default", function()
+      assert.is_true(DB:GetGroupsEnabled(const.BAG_KIND.BACKPACK))
+    end)
+
+    it("SetGroupsEnabled changes the value", function()
+      DB:SetGroupsEnabled(const.BAG_KIND.BANK, false)
+      assert.is_false(DB:GetGroupsEnabled(const.BAG_KIND.BANK))
+    end)
+
+    it("GetGroupsEnabled returns true when groupsEnabled is nil", function()
+      DB.data.profile.groupsEnabled = nil
+      assert.is_true(DB:GetGroupsEnabled(const.BAG_KIND.BANK))
+    end)
+
+    it("GetGroupsEnabled returns true when kind entry is nil", function()
+      DB.data.profile.groupsEnabled = {}
+      assert.is_true(DB:GetGroupsEnabled(const.BAG_KIND.BACKPACK))
+    end)
+  end)
+
+  -- ─── Bag size ──────────────────────────────────────────────────────────────────
+
+  describe("bag size", function()
+
+    it("GetBagSizeInfo returns size for view/kind", function()
+      local size = DB:GetBagSizeInfo(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID)
+      assert.is_not_nil(size)
+      assert.are.equal(2, size.columnCount)
+      assert.are.equal(7, size.itemsPerRow)
+    end)
+
+    it("SetBagViewSizeColumn changes column count", function()
+      DB:SetBagViewSizeColumn(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID, 3)
+      local size = DB:GetBagSizeInfo(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID)
+      assert.are.equal(3, size.columnCount)
+    end)
+
+    it("SetBagViewSizeItems changes items per row", function()
+      DB:SetBagViewSizeItems(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID, 10)
+      local size = DB:GetBagSizeInfo(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID)
+      assert.are.equal(10, size.itemsPerRow)
+    end)
+
+    it("SetBagViewSizeScale changes scale", function()
+      DB:SetBagViewSizeScale(const.BAG_KIND.BANK, const.BAG_VIEW.LIST, 150)
+      local size = DB:GetBagSizeInfo(const.BAG_KIND.BANK, const.BAG_VIEW.LIST)
+      assert.are.equal(150, size.scale)
+    end)
+
+    it("SetBagViewSizeOpacity changes opacity", function()
+      DB:SetBagViewSizeOpacity(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID, 50)
+      local size = DB:GetBagSizeInfo(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID)
+      assert.are.equal(50, size.opacity)
+    end)
+
+    it("GetBagViewFrameSize / SetBagViewFrameSize", function()
+      DB:SetBagViewFrameSize(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID, 800, 600)
+      local w, h = DB:GetBagViewFrameSize(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID)
+      assert.are.equal(800, w)
+      assert.are.equal(600, h)
+    end)
+  end)
+
+  -- ─── Item level ────────────────────────────────────────────────────────────────
+
+  describe("item level", function()
+
+    it("GetItemLevelOptions returns kind-specific options", function()
+      local opts = DB:GetItemLevelOptions(const.BAG_KIND.BACKPACK)
+      assert.is_true(opts.enabled)
+      assert.is_true(opts.color)
+    end)
+
+    it("SetItemLevelEnabled / SetItemLevelColorEnabled", function()
+      DB:SetItemLevelEnabled(const.BAG_KIND.BANK, false)
+      DB:SetItemLevelColorEnabled(const.BAG_KIND.BANK, false)
+      local opts = DB:GetItemLevelOptions(const.BAG_KIND.BANK)
+      assert.is_false(opts.enabled)
+      assert.is_false(opts.color)
+    end)
+
+    it("GetItemLevelColors returns color table", function()
+      local colors = DB:GetItemLevelColors()
+      assert.is_not_nil(colors.low)
+      assert.is_not_nil(colors.mid)
+      assert.is_not_nil(colors.high)
+      assert.is_not_nil(colors.max)
+    end)
+
+    it("SetItemLevelColor updates a specific color", function()
+      local newColor = { red = 0.1, green = 0.2, blue = 0.3, alpha = 0.5 }
+      DB:SetItemLevelColor("low", newColor)
+      local colors = DB:GetItemLevelColors()
+      assert.are.same(newColor, colors.low)
+    end)
+
+    it("GetMaxItemLevel returns per-character max", function()
+      -- Initially 1 (default)
+      local max = DB:GetMaxItemLevel()
+      assert.are.equal(1, max)
+    end)
+
+    it("UpdateMaxItemLevel updates when higher", function()
+      DB:UpdateMaxItemLevel(100)
+      assert.are.equal(100, DB:GetMaxItemLevel())
+    end)
+
+    it("UpdateMaxItemLevel does not decrease", function()
+      DB:UpdateMaxItemLevel(100)
+      DB:UpdateMaxItemLevel(50)
+      assert.are.equal(100, DB:GetMaxItemLevel())
+    end)
+  end)
+
+  -- ─── Sort types ────────────────────────────────────────────────────────────────
+
+  describe("sort types", function()
+
+    it("GetSectionSortType / SetSectionSortType", function()
+      DB:SetSectionSortType(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID, const.SECTION_SORT_TYPE.SIZE_DESCENDING)
+      assert.are.equal(const.SECTION_SORT_TYPE.SIZE_DESCENDING, DB:GetSectionSortType(const.BAG_KIND.BACKPACK, const.BAG_VIEW.SECTION_GRID))
+    end)
+
+    it("GetItemSortType / SetItemSortType", function()
+      DB:SetItemSortType(const.BAG_KIND.BANK, const.BAG_VIEW.LIST, const.ITEM_SORT_TYPE.ITEM_LEVEL)
+      assert.are.equal(const.ITEM_SORT_TYPE.ITEM_LEVEL, DB:GetItemSortType(const.BAG_KIND.BANK, const.BAG_VIEW.LIST))
+    end)
+  end)
+
+  -- ─── Extra glowy buttons ───────────────────────────────────────────────────────
+
+  describe("extra glowy buttons", function()
+
+    it("GetExtraGlowyButtons / SetExtraGlowyButtons", function()
+      DB:SetExtraGlowyButtons(const.BAG_KIND.BACKPACK, true)
+      assert.is_true(DB:GetExtraGlowyButtons(const.BAG_KIND.BACKPACK))
+    end)
+  end)
+
+  -- ─── Show full section names / free space ──────────────────────────────────────
+
+  describe("display toggles", function()
+
+    it("GetShowFullSectionNames / SetShowFullSectionNames", function()
+      DB:SetShowFullSectionNames(const.BAG_KIND.BANK, true)
+      assert.is_true(DB:GetShowFullSectionNames(const.BAG_KIND.BANK))
+    end)
+
+    it("GetShowAllFreeSpace / SetShowAllFreeSpace", function()
+      DB:SetShowAllFreeSpace(const.BAG_KIND.BACKPACK, true)
+      assert.is_true(DB:GetShowAllFreeSpace(const.BAG_KIND.BACKPACK))
+    end)
+  end)
+
+  -- ─── Theme ─────────────────────────────────────────────────────────────────────
+
+  describe("theme", function()
+
+    it("GetTheme / SetTheme", function()
+      DB:SetTheme("DarkMode")
+      assert.are.equal("DarkMode", DB:GetTheme())
+    end)
+
+    it("GetUpgradeIconProvider / SetUpgradeIconProvider", function()
+      DB:SetUpgradeIconProvider("Pawn")
+      assert.are.equal("Pawn", DB:GetUpgradeIconProvider())
+    end)
+  end)
+
+  -- ─── Stacking ──────────────────────────────────────────────────────────────────
+
+  describe("stacking", function()
+
+    it("GetStackingOptions returns kind-specific stacking config", function()
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BACKPACK)
+      assert.is_not_nil(opts)
+      assert.is_true(opts.mergeStacks)
+    end)
+
+    it("SetMergeItems toggles mergeStacks", function()
+      DB:SetMergeItems(const.BAG_KIND.BANK, false)
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BANK)
+      assert.is_false(opts.mergeStacks)
+    end)
+
+    it("SetMergeUnstackable toggles mergeUnstackable", function()
+      DB:SetMergeUnstackable(const.BAG_KIND.BACKPACK, false)
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BACKPACK)
+      assert.is_false(opts.mergeUnstackable)
+    end)
+
+    it("SetUnmergeAtShop toggles unmergeAtShop", function()
+      DB:SetUnmergeAtShop(const.BAG_KIND.BANK, false)
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BANK)
+      assert.is_false(opts.unmergeAtShop)
+    end)
+
+    it("SetDontMergePartial toggles dontMergePartial", function()
+      DB:SetDontMergePartial(const.BAG_KIND.BACKPACK, true)
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BACKPACK)
+      assert.is_true(opts.dontMergePartial)
+    end)
+
+    it("SetDontMergeTransmog toggles dontMergeTransmog", function()
+      DB:SetDontMergeTransmog(const.BAG_KIND.BANK, true)
+      local opts = DB:GetStackingOptions(const.BAG_KIND.BANK)
+      assert.is_true(opts.dontMergeTransmog)
+    end)
+  end)
+
+  -- ─── Category filters ──────────────────────────────────────────────────────────
+
+  describe("category filters", function()
+
+    it("GetCategoryFilter / SetCategoryFilter", function()
+      DB:SetCategoryFilter(const.BAG_KIND.BACKPACK, "Type", false)
+      assert.is_false(DB:GetCategoryFilter(const.BAG_KIND.BACKPACK, "Type"))
+    end)
+
+    it("GetCategoryFilters returns filter table for a kind", function()
+      local filters = DB:GetCategoryFilters(const.BAG_KIND.BANK)
+      assert.is_true(filters.Type)
+      assert.is_false(filters.Subtype)
+    end)
+  end)
+
+  -- ─── Item locking ──────────────────────────────────────────────────────────────
+
+  describe("item locking", function()
+
+    it("SetItemLock / GetItemLock", function()
+      DB:SetItemLock("guid-123", true)
+      assert.is_true(DB:GetItemLock("guid-123"))
+    end)
+
+    it("GetItemLock returns nil for unknown guid", function()
+      assert.is_nil(DB:GetItemLock("guid-nonexistent"))
+    end)
+  end)
+
+  -- ─── First time menu ───────────────────────────────────────────────────────────
+
+  describe("first time menu", function()
+
+    it("GetFirstTimeMenu / SetFirstTimeMenu", function()
+      DB:SetFirstTimeMenu(true)
+      assert.is_true(DB:GetFirstTimeMenu())
+    end)
+  end)
+
+  -- ─── Category options ──────────────────────────────────────────────────────────
+
+  describe("category options", function()
+
+    it("GetCategoryOptions returns defaults for unknown category", function()
+      local opts = DB:GetCategoryOptions("NewCategory")
+      assert.is_true(opts.shown)
+    end)
+
+    it("GetCategoryOptions returns stored options", function()
+      DB.data.profile.categoryOptions["TestCat"] = { shown = false }
+      local opts = DB:GetCategoryOptions("TestCat")
+      assert.is_false(opts.shown)
+    end)
+  end)
+
+  -- ─── SaveItemToCategory / DeleteItemFromCategory ───────────────────────────────
+
+  describe("item category assignment", function()
+
+    it("SaveItemToCategory adds an item to a category", function()
+      DB.data.profile.customCategoryFilters["Weapons"] = {
+        name = "Weapons", itemList = {}, enabled = { [0] = true, [1] = true }
+      }
+      DB:SaveItemToCategory(1234, "Weapons")
+      assert.is_true(DB.data.profile.customCategoryFilters["Weapons"].itemList[1234])
+      assert.are.equal("Weapons", DB.data.profile.customCategoryIndex[1234])
+    end)
+
+    it("SaveItemToCategory moves item from old category to new", function()
+      DB.data.profile.customCategoryFilters["Old"] = {
+        name = "Old", itemList = { [1234] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryFilters["New"] = {
+        name = "New", itemList = {}, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[1234] = "Old"
+
+      DB:SaveItemToCategory(1234, "New")
+      assert.is_nil(DB.data.profile.customCategoryFilters["Old"].itemList[1234])
+      assert.is_true(DB.data.profile.customCategoryFilters["New"].itemList[1234])
+      assert.are.equal("New", DB.data.profile.customCategoryIndex[1234])
+    end)
+
+    it("DeleteItemFromCategory removes item", function()
+      DB.data.profile.customCategoryFilters["Weapons"] = {
+        name = "Weapons", itemList = { [1234] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[1234] = "Weapons"
+      DB:DeleteItemFromCategory(1234, "Weapons")
+      assert.is_nil(DB.data.profile.customCategoryFilters["Weapons"].itemList[1234])
+      assert.is_nil(DB.data.profile.customCategoryIndex[1234])
+    end)
+
+    it("GetItemCategoryByItemID returns category for an item", function()
+      DB.data.profile.customCategoryFilters["Armor"] = {
+        name = "Armor", itemList = { [5678] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[5678] = "Armor"
+      local cat = DB:GetItemCategoryByItemID(5678)
+      assert.are.equal("Armor", cat.name)
+    end)
+
+    it("GetItemCategoryByItemID returns empty table for unknown item", function()
+      local cat = DB:GetItemCategoryByItemID(9999)
+      assert.same({}, cat)
+    end)
+  end)
+
+  -- ─── Category enabled ──────────────────────────────────────────────────────────
+
+  describe("category enabled", function()
+
+    it("SetItemCategoryEnabled sets enabled per kind", function()
+      DB.data.profile.customCategoryFilters["Weapons"] = {
+        name = "Weapons", itemList = {}, enabled = { [0] = true, [1] = true }
+      }
+      DB:SetItemCategoryEnabled(const.BAG_KIND.BANK, "Weapons", false)
+      assert.is_false(DB.data.profile.customCategoryFilters["Weapons"].enabled[const.BAG_KIND.BANK])
+      assert.is_true(DB.data.profile.customCategoryFilters["Weapons"].enabled[const.BAG_KIND.BACKPACK])
+    end)
+
+    it("SetEphemeralItemCategoryEnabled sets enabled for ephemeral", function()
+      DB.data.profile.ephemeralCategoryFilters["Temp"] = {
+        name = "Temp", enabled = { [0] = true, [1] = true }
+      }
+      DB:SetEphemeralItemCategoryEnabled(const.BAG_KIND.BACKPACK, "Temp", false)
+      assert.is_false(DB.data.profile.ephemeralCategoryFilters["Temp"].enabled[const.BAG_KIND.BACKPACK])
+    end)
+  end)
+
+  -- ─── Category CRUD ─────────────────────────────────────────────────────────────
+
+  describe("category CRUD", function()
+
+    it("CreateOrUpdateCategory creates a persistent category", function()
+      DB:CreateOrUpdateCategory({
+        name = "Persistent", save = true, enabled = { [0] = true, [1] = true }
+      })
+      assert.is_not_nil(DB.data.profile.customCategoryFilters["Persistent"])
+    end)
+
+    it("CreateOrUpdateCategory creates an ephemeral category", function()
+      DB:CreateOrUpdateCategory({
+        name = "Ephemeral", save = false, enabled = { [0] = true, [1] = true }
+      })
+      assert.is_nil(DB.data.profile.customCategoryFilters["Ephemeral"])
+      assert.is_not_nil(DB.data.profile.ephemeralCategoryFilters["Ephemeral"])
+    end)
+
+    it("CreateOrUpdateCategory updates customCategoryIndex for persistent categories", function()
+      DB:CreateOrUpdateCategory({
+        name = "Indexed", save = true, itemList = { [42] = true, [99] = true }, enabled = { [0] = true, [1] = true }
+      })
+      assert.are.equal("Indexed", DB.data.profile.customCategoryIndex[42])
+      assert.are.equal("Indexed", DB.data.profile.customCategoryIndex[99])
+    end)
+
+    it("DeleteItemCategory removes persistent category", function()
+      DB.data.profile.customCategoryFilters["Gone"] = {
+        name = "Gone", itemList = {}, enabled = { [0] = true, [1] = true }
+      }
+      DB:DeleteItemCategory("Gone")
+      assert.is_nil(DB.data.profile.customCategoryFilters["Gone"])
+    end)
+
+    it("DeleteItemCategory removes ephemeral category", function()
+      DB.data.profile.ephemeralCategoryFilters["TempGone"] = {
+        name = "TempGone", enabled = { [0] = true, [1] = true }
+      }
+      DB:DeleteItemCategory("TempGone")
+      assert.is_nil(DB.data.profile.ephemeralCategoryFilters["TempGone"])
+    end)
+
+    it("DeleteItemCategory cleans up items from index", function()
+      DB.data.profile.customCategoryFilters["CleanMe"] = {
+        name = "CleanMe", itemList = { [1] = true, [2] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[1] = "CleanMe"
+      DB.data.profile.customCategoryIndex[2] = "CleanMe"
+      DB:DeleteItemCategory("CleanMe")
+      assert.is_nil(DB.data.profile.customCategoryIndex[1])
+      assert.is_nil(DB.data.profile.customCategoryIndex[2])
+    end)
+
+    it("WipeItemCategory clears items from persistent category", function()
+      DB.data.profile.customCategoryFilters["WipeMe"] = {
+        name = "WipeMe", itemList = { [5] = true, [10] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[5] = "WipeMe"
+      DB.data.profile.customCategoryIndex[10] = "WipeMe"
+      DB:WipeItemCategory("WipeMe")
+      assert.same({}, DB.data.profile.customCategoryFilters["WipeMe"].itemList)
+      assert.is_nil(DB.data.profile.customCategoryIndex[5])
+    end)
+
+    it("ItemCategoryExists checks persistent categories", function()
+      DB.data.profile.customCategoryFilters["Exists"] = { name = "Exists", itemList = {} }
+      assert.is_true(DB:ItemCategoryExists("Exists"))
+    end)
+
+    it("ItemCategoryExists returns false for unknown", function()
+      assert.is_false(DB:ItemCategoryExists("Nope"))
+    end)
+
+    it("GetAllItemCategories sets name on each category", function()
+      DB.data.profile.customCategoryFilters["A"] = { name = "OldA", itemList = {} }
+      local all = DB:GetAllItemCategories()
+      assert.are.equal("A", all["A"].name)
+    end)
+
+    it("GetItemCategory returns persistent category", function()
+      DB.data.profile.customCategoryFilters["Cat"] = { name = "Cat", itemList = {} }
+      assert.is_not_nil(DB:GetItemCategory("Cat"))
+    end)
+
+    it("GetEphemeralItemCategory returns ephemeral category", function()
+      DB.data.profile.ephemeralCategoryFilters["Eph"] = { name = "Eph" }
+      assert.is_not_nil(DB:GetEphemeralItemCategory("Eph"))
+    end)
+
+    it("GetAllEphemeralItemCategories returns all ephemeral", function()
+      DB.data.profile.ephemeralCategoryFilters["E1"] = { name = "E1" }
+      DB.data.profile.ephemeralCategoryFilters["E2"] = { name = "E2" }
+      local all = DB:GetAllEphemeralItemCategories()
+      assert.is_not_nil(all["E1"])
+      assert.is_not_nil(all["E2"])
+    end)
+  end)
+
+  -- ─── RenameCategory ────────────────────────────────────────────────────────────
+
+  describe("RenameCategory", function()
+
+    before_each(function()
+      DB.data.profile.customCategoryFilters["OldName"] = {
+        name = "OldName", itemList = { [100] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[100] = "OldName"
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["OldName"] = 1
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BANK]["OldName"] = 2
+      DB.data.profile.ephemeralCategoryFilters["OldName"] = { name = "OldName", enabled = { [0] = true, [1] = true } }
+      DB.data.profile.categoryOptions["OldName"] = { shown = false }
+      DB.data.profile.collapsedSections[const.BAG_KIND.BACKPACK]["OldName"] = true
+      DB.data.profile.collapsedSections[const.BAG_KIND.BANK]["OldName"] = false
+      DB.data.profile.customSectionSort[const.BAG_KIND.BACKPACK]["OldName"] = 5
+      DB.data.profile.customSectionSort[const.BAG_KIND.BANK]["OldName"] = 3
+    end)
+
+    it("renames successfully", function()
+      local ok = DB:RenameCategory("OldName", "NewName")
+      assert.is_true(ok)
+    end)
+
+    it("moves main category data", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.is_nil(DB.data.profile.customCategoryFilters["OldName"])
+      assert.is_not_nil(DB.data.profile.customCategoryFilters["NewName"])
+      assert.are.equal("NewName", DB.data.profile.customCategoryFilters["NewName"].name)
+    end)
+
+    it("updates customCategoryIndex", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.are.equal("NewName", DB.data.profile.customCategoryIndex[100])
+    end)
+
+    it("updates categoryToGroup for all kinds", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.are.equal(1, DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["NewName"])
+      assert.are.equal(2, DB.data.profile.categoryToGroup[const.BAG_KIND.BANK]["NewName"])
+      assert.is_nil(DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["OldName"])
+    end)
+
+    it("updates ephemeral filters", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.is_nil(DB.data.profile.ephemeralCategoryFilters["OldName"])
+      assert.is_not_nil(DB.data.profile.ephemeralCategoryFilters["NewName"])
+    end)
+
+    it("updates categoryOptions", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.is_nil(DB.data.profile.categoryOptions["OldName"])
+      assert.is_false(DB.data.profile.categoryOptions["NewName"].shown)
+    end)
+
+    it("updates collapsedSections for all kinds", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.is_true(DB.data.profile.collapsedSections[const.BAG_KIND.BACKPACK]["NewName"])
+      assert.is_false(DB.data.profile.collapsedSections[const.BAG_KIND.BANK]["NewName"])
+    end)
+
+    it("updates customSectionSort for all kinds", function()
+      DB:RenameCategory("OldName", "NewName")
+      assert.are.equal(5, DB.data.profile.customSectionSort[const.BAG_KIND.BACKPACK]["NewName"])
+      assert.are.equal(3, DB.data.profile.customSectionSort[const.BAG_KIND.BANK]["NewName"])
+    end)
+
+    it("fails when old category doesn't exist", function()
+      local ok = DB:RenameCategory("GhostCategory", "NewName")
+      assert.is_false(ok)
+    end)
+
+    it("fails when new name already exists", function()
+      DB.data.profile.customCategoryFilters["NewName"] = { name = "NewName", itemList = {} }
+      local ok = DB:RenameCategory("OldName", "NewName")
+      assert.is_false(ok)
+    end)
+
+    it("fails when new name is empty", function()
+      local ok = DB:RenameCategory("OldName", "   ")
+      assert.is_false(ok)
+    end)
+
+    it("cleans up grouped sub-categories", function()
+      DB.data.profile.ephemeralCategoryFilters["OldName - Consumable"] = { name = "OldName - Consumable" }
+      DB.data.profile.categoryOptions["OldName - Consumable"] = { shown = true }
+      DB.data.profile.collapsedSections[const.BAG_KIND.BACKPACK]["OldName - Consumable"] = true
+      DB.data.profile.customSectionSort[const.BAG_KIND.BANK]["OldName - Consumable"] = 2
+
+      DB:RenameCategory("OldName", "NewName")
+
+      assert.is_nil(DB.data.profile.ephemeralCategoryFilters["OldName - Consumable"])
+      assert.is_nil(DB.data.profile.categoryOptions["OldName - Consumable"])
+      assert.is_nil(DB.data.profile.collapsedSections[const.BAG_KIND.BACKPACK]["OldName - Consumable"])
+      assert.is_nil(DB.data.profile.customSectionSort[const.BAG_KIND.BANK]["OldName - Consumable"])
+    end)
+  end)
+
+  -- ─── Section collapse ──────────────────────────────────────────────────────────
+
+  describe("section collapse", function()
+
+    it("GetSectionCollapsed returns false by default", function()
+      assert.is_false(DB:GetSectionCollapsed(const.BAG_KIND.BACKPACK, "SomeSection"))
+    end)
+
+    it("SetSectionCollapsed sets collapse state", function()
+      DB:SetSectionCollapsed(const.BAG_KIND.BANK, "MySection", true)
+      assert.is_true(DB:GetSectionCollapsed(const.BAG_KIND.BANK, "MySection"))
+    end)
+
+    it("ToggleSectionCollapsed flips the state", function()
+      DB:ToggleSectionCollapsed(const.BAG_KIND.BACKPACK, "ToggleMe")
+      assert.is_true(DB:GetSectionCollapsed(const.BAG_KIND.BACKPACK, "ToggleMe"))
+      DB:ToggleSectionCollapsed(const.BAG_KIND.BACKPACK, "ToggleMe")
+      assert.is_false(DB:GetSectionCollapsed(const.BAG_KIND.BACKPACK, "ToggleMe"))
+    end)
+  end)
+
+  -- ─── Custom section sort ───────────────────────────────────────────────────────
+
+  describe("custom section sort", function()
+
+    it("ClearCustomSectionSort wipes the kind", function()
+      DB.data.profile.customSectionSort[const.BAG_KIND.BACKPACK]["Pinned"] = 10
+      DB:ClearCustomSectionSort(const.BAG_KIND.BACKPACK)
+      assert.same({}, DB.data.profile.customSectionSort[const.BAG_KIND.BACKPACK])
+    end)
+
+    it("SetCustomSectionSort / GetCustomSectionSort", function()
+      DB:SetCustomSectionSort(const.BAG_KIND.BANK, "Important", 1)
+      local sort = DB:GetCustomSectionSort(const.BAG_KIND.BANK)
+      assert.are.equal(1, sort["Important"])
+    end)
+  end)
+
+  -- ─── Groups ────────────────────────────────────────────────────────────────────
+
+  describe("groups", function()
+
+    it("GetAllGroups returns groups for a kind", function()
+      local groups = DB:GetAllGroups(const.BAG_KIND.BACKPACK)
+      assert.is_not_nil(groups[1])
+      assert.are.equal("Backpack", groups[1].name)
+    end)
+
+    it("GetGroup returns specific group", function()
+      local group = DB:GetGroup(const.BAG_KIND.BACKPACK, 1)
+      assert.are.equal("Backpack", group.name)
+    end)
+
+    it("GetGroup returns nil for non-existent group", function()
+      assert.is_nil(DB:GetGroup(const.BAG_KIND.BANK, 999))
+    end)
+
+    it("CreateGroup creates a new group and returns its ID", function()
+      local id = DB:CreateGroup(const.BAG_KIND.BACKPACK, "Test Group")
+      assert.are.equal(2, id)
+      local group = DB:GetGroup(const.BAG_KIND.BACKPACK, id)
+      assert.are.equal("Test Group", group.name)
+      assert.are.equal(const.BAG_KIND.BACKPACK, group.kind)
+    end)
+
+    it("CreateGroup increments groupCounter", function()
+      DB:CreateGroup(const.BAG_KIND.BACKPACK, "Group A")
+      DB:CreateGroup(const.BAG_KIND.BACKPACK, "Group B")
+      assert.are.equal(3, DB.data.profile.groupCounter[const.BAG_KIND.BACKPACK])
+    end)
+
+    it("DeleteGroup removes a non-default group", function()
+      DB.data.profile.groups[const.BAG_KIND.BACKPACK][10] = {
+        id = 10, name = "DeleteMe", order = 10, kind = const.BAG_KIND.BACKPACK
+      }
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["CatA"] = 10
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["CatB"] = 10
+      DB:DeleteGroup(const.BAG_KIND.BACKPACK, 10)
+      assert.is_nil(DB:GetGroup(const.BAG_KIND.BACKPACK, 10))
+      assert.is_nil(DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["CatA"])
+      assert.is_nil(DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["CatB"])
+    end)
+
+    it("DeleteGroup does not delete default groups", function()
+      DB:DeleteGroup(const.BAG_KIND.BACKPACK, 1)
+      assert.is_not_nil(DB:GetGroup(const.BAG_KIND.BACKPACK, 1))
+    end)
+
+    it("DeleteGroup switches active group to default for backpack", function()
+      DB.data.profile.activeGroup[const.BAG_KIND.BACKPACK] = 10
+      DB.data.profile.groups[const.BAG_KIND.BACKPACK][10] = {
+        id = 10, name = "Active", order = 10, kind = const.BAG_KIND.BACKPACK
+      }
+      DB:DeleteGroup(const.BAG_KIND.BACKPACK, 10)
+      assert.are.equal(1, DB.data.profile.activeGroup[const.BAG_KIND.BACKPACK])
+    end)
+
+    it("DeleteGroup switches active group to default bank", function()
+      -- Need a bank group first
+      local bankId = DB:CreateGroup(const.BAG_KIND.BANK, "Bank Default", _G.Enum.BankType.Character)
+      DB.data.profile.groups[const.BAG_KIND.BANK][bankId].isDefault = true
+
+      DB.data.profile.activeGroup[const.BAG_KIND.BANK] = 50
+      DB.data.profile.groups[const.BAG_KIND.BANK][50] = {
+        id = 50, name = "Active Bank", order = 50, kind = const.BAG_KIND.BANK
+      }
+      DB:DeleteGroup(const.BAG_KIND.BANK, 50)
+      assert.are.equal(bankId, DB.data.profile.activeGroup[const.BAG_KIND.BANK])
+    end)
+
+    it("RenameGroup updates group name", function()
+      DB.data.profile.groups[const.BAG_KIND.BACKPACK][5] = {
+        id = 5, name = "OldName", order = 5, kind = const.BAG_KIND.BACKPACK
+      }
+      DB:RenameGroup(const.BAG_KIND.BACKPACK, 5, "NewName")
+      assert.are.equal("NewName", DB.data.profile.groups[const.BAG_KIND.BACKPACK][5].name)
+    end)
+
+    it("RenameGroup does nothing for non-existent group", function()
+      DB:RenameGroup(const.BAG_KIND.BACKPACK, 999, "Whatever")
+      assert.is_nil(DB:GetGroup(const.BAG_KIND.BACKPACK, 999))
+    end)
+
+    it("GetNextGroupID returns the next available ID", function()
+      assert.are.equal(2, DB:GetNextGroupID(const.BAG_KIND.BACKPACK))
+      assert.are.equal(1, DB:GetNextGroupID(const.BAG_KIND.BANK))
+    end)
+  end)
+
+  -- ─── Category-to-group mapping ─────────────────────────────────────────────────
+
+  describe("category-to-group mapping", function()
+
+    it("SetCategoryGroup / GetCategoryGroup", function()
+      DB:SetCategoryGroup(const.BAG_KIND.BACKPACK, "Weapons", 5)
+      assert.are.equal(5, DB:GetCategoryGroup(const.BAG_KIND.BACKPACK, "Weapons"))
+    end)
+
+    it("GetCategoryGroup returns nil for unmapped category", function()
+      assert.is_nil(DB:GetCategoryGroup(const.BAG_KIND.BANK, "Unmapped"))
+    end)
+
+    it("RemoveCategoryFromGroup clears mapping", function()
+      DB:SetCategoryGroup(const.BAG_KIND.BACKPACK, "RemoveMe", 3)
+      DB:RemoveCategoryFromGroup(const.BAG_KIND.BACKPACK, "RemoveMe")
+      assert.is_nil(DB:GetCategoryGroup(const.BAG_KIND.BACKPACK, "RemoveMe"))
+    end)
+
+    it("GetGroupCategories returns categories in a group", function()
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["Cat1"] = 10
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["Cat2"] = 10
+      DB.data.profile.categoryToGroup[const.BAG_KIND.BACKPACK]["Cat3"] = 20
+
+      local cats = DB:GetGroupCategories(const.BAG_KIND.BACKPACK, 10)
+      assert.is_true(cats["Cat1"])
+      assert.is_true(cats["Cat2"])
+      assert.is_nil(cats["Cat3"])
+    end)
+  end)
+
+  -- ─── Active group ──────────────────────────────────────────────────────────────
+
+  describe("active group", function()
+
+    it("GetActiveGroup returns stored active group", function()
+      DB:SetActiveGroup(const.BAG_KIND.BANK, 5)
+      assert.are.equal(5, DB:GetActiveGroup(const.BAG_KIND.BANK))
+    end)
+
+    it("GetActiveGroup defaults to 1", function()
+      DB.data.profile.activeGroup = {}
+      assert.are.equal(1, DB:GetActiveGroup(const.BAG_KIND.BACKPACK))
+    end)
+  end)
+
+  -- ─── Group order ───────────────────────────────────────────────────────────────
+
+  describe("group order", function()
+
+    it("SetGroupOrder / GetGroupOrder", function()
+      DB:SetGroupOrder(const.BAG_KIND.BACKPACK, 1, 42)
+      assert.are.equal(42, DB:GetGroupOrder(const.BAG_KIND.BACKPACK, 1))
+    end)
+
+    it("GetGroupOrder defaults to group ID", function()
+      assert.are.equal(1, DB:GetGroupOrder(const.BAG_KIND.BACKPACK, 1))
+    end)
+  end)
+
+  -- ─── Position / anchor ─────────────────────────────────────────────────────────
+
+  describe("positions and anchors", function()
+
+    it("GetBagPosition returns position data", function()
+      local pos = DB:GetBagPosition(const.BAG_KIND.BACKPACK)
+      assert.is_not_nil(pos)
+    end)
+
+    it("GetAnchorPosition returns anchor position data", function()
+      local pos = DB:GetAnchorPosition(const.BAG_KIND.BANK)
+      assert.is_not_nil(pos)
+    end)
+
+    it("GetAnchorState returns anchor state", function()
+      local state = DB:GetAnchorState(const.BAG_KIND.BACKPACK)
+      assert.is_false(state.enabled)
+      assert.is_false(state.shown)
+    end)
+  end)
+
+  -- ─── Search categories ─────────────────────────────────────────────────────────
+
+  describe("search categories", function()
+
+    it("IsSearchCategory returns true for registered search categories", function()
+      DB.data.profile.searchCategories = { ["Smart Search"] = true }
+      assert.is_true(DB:IsSearchCategory("Smart Search"))
+    end)
+
+    it("IsSearchCategory returns false for non-search categories", function()
+      DB.data.profile.searchCategories = {}
+      assert.is_false(DB:IsSearchCategory("NotHere"))
+    end)
+  end)
+
+  -- ─── Export / Import ───────────────────────────────────────────────────────────
+
+  describe("import/export", function()
+
+    it("ExportSettings returns a base64 string with !BB prefix", function()
+      local exported = DB:ExportSettings()
+      assert.is_not_nil(exported)
+      assert.is_not_nil(exported:match("^!BB"))
+    end)
+
+    it("ImportSettings returns false for nil data", function()
+      local ok, err = DB:ImportSettings(nil)
+      assert.is_false(ok)
+      assert.is_not_nil(err)
+    end)
+
+    it("ImportSettings returns false for empty string", function()
+      local ok = DB:ImportSettings("")
+      assert.is_false(ok)
+    end)
+
+    it("ImportSettings returns false for missing !BB prefix", function()
+      local ok, err = DB:ImportSettings("garbage")
+      assert.is_false(ok)
+      assert.is_not_nil(string.find(err, "prefix"))
+    end)
+
+    it("ImportSettings returns false for invalid base64", function()
+      local ok = DB:ImportSettings("!BB!!!not-valid-base64!!!")
+      assert.is_false(ok)
+    end)
+
+    it("round-trip export/import preserves category data", function()
+      DB.data.profile.customCategoryFilters["ExportTest"] = {
+        name = "ExportTest", itemList = { [42] = true }, enabled = { [0] = true, [1] = true }
+      }
+      DB.data.profile.customCategoryIndex[42] = "ExportTest"
+
+      local exported = DB:ExportSettings()
+      -- Reset
+      DB.data.profile.customCategoryFilters = {}
+      DB.data.profile.customCategoryIndex = {}
+
+      local ok, msg = DB:ImportSettings(exported)
+      assert.is_true(ok, msg)
+      assert.is_not_nil(DB.data.profile.customCategoryFilters["ExportTest"])
+      assert.is_true(DB.data.profile.customCategoryFilters["ExportTest"].itemList[42])
+      assert.are.equal("ExportTest", DB.data.profile.customCategoryIndex[42])
+    end)
+  end)
+
+  -- ─── Profile management ─────────────────────────────────────────────────────────
+
+  describe("profile management", function()
+
+    it("GetCurrentProfileName returns current profile name", function()
+      local name = DB:GetCurrentProfileName()
+      assert.is_not_nil(name)
+      assert.is_true(type(name) == "string")
+    end)
+
+    it("GetAvailableProfiles returns a list", function()
+      local profiles = DB:GetAvailableProfiles()
+      assert.is_not_nil(profiles)
+      assert.is_true(#profiles >= 1)
+    end)
+
+    it("SwitchToProfile returns true", function()
+      local ok = DB:SwitchToProfile("Default")
+      assert.is_true(ok)
+    end)
+
+    it("SwitchToProfile returns false for empty name", function()
+      local ok = DB:SwitchToProfile("")
+      assert.is_false(ok)
+    end)
+
+    it("CreateProfile creates a new profile", function()
+      local ok, msg = DB:CreateProfile("TestProfile")
+      assert.is_true(ok, msg)
+    end)
+
+    it("CreateProfile fails for duplicate name", function()
+      DB:CreateProfile("DupProfile")
+      local ok, _ = DB:CreateProfile("DupProfile")
+      assert.is_false(ok)
+    end)
+
+    it("CreateProfile fails for empty name", function()
+      local ok, _ = DB:CreateProfile("")
+      assert.is_false(ok)
+    end)
+
+    it("CopyFromProfile returns false for non-existent source", function()
+      local ok, _ = DB:CopyFromProfile("NonexistentProfile")
+      assert.is_false(ok)
+    end)
+
+    it("CopyFromProfile returns false for empty name", function()
+      local ok, _ = DB:CopyFromProfile("")
+      assert.is_false(ok)
+    end)
+
+    it("RenameProfile cannot rename Default", function()
+      local ok, _ = DB:RenameProfile("Default", "NewDefault")
+      assert.is_false(ok)
+    end)
+
+    it("RenameProfile returns false for empty new name", function()
+      DB:CreateProfile("RenameMe")
+      local ok, _ = DB:RenameProfile("RenameMe", "")
+      assert.is_false(ok)
+    end)
+
+    it("DeleteProfile cannot delete Default", function()
+      local ok, _ = DB:DeleteProfile("Default")
+      assert.is_false(ok)
+    end)
+
+    it("DeleteProfile cannot delete active profile", function()
+      local currentName = DB:GetCurrentProfileName()
+      local ok, _ = DB:DeleteProfile(currentName)
+      assert.is_false(ok)
+    end)
+
+    it("ResetCurrentProfile returns true", function()
+      local ok, _ = DB:ResetCurrentProfile()
+      assert.is_true(ok)
+    end)
+
+    it("GetProfileCharacterCounts returns table", function()
+      local counts = DB:GetProfileCharacterCounts()
+      assert.is_not_nil(counts)
+    end)
+  end)
+end)

--- a/spec/equipmentsets_spec.lua
+++ b/spec/equipmentsets_spec.lua
@@ -1,0 +1,321 @@
+-- equipmentsets_spec.lua -- Unit tests for data/equipmentsets.lua
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- The module reads version flags directly from the addon object
+addon.isClassic = false
+addon.isAnniversary = false
+addon.isRetail = true
+addon.isMidnight = false
+
+StubBetterBagsModule("Constants")
+StubBetterBagsModule("Localization")
+
+LoadBetterBagsModule("data/equipmentsets.lua")
+local equipmentSets = addon:GetModule("EquipmentSets")
+
+describe("EquipmentSets", function()
+
+  before_each(function()
+    addon.isClassic = false
+    addon.isAnniversary = false
+    addon.isRetail = true
+    addon.isMidnight = false
+
+    _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {} end
+    _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "" end
+    _G.C_EquipmentSet.GetItemLocations = function() return {} end
+
+    _G.EquipmentManager_UnpackLocation = function()
+      return 0, false, true, false, 1, 0
+    end
+    _G.EquipmentManager_GetLocationData = function()
+      return { isBank = false, isBags = true, slot = 1, bag = 0 }
+    end
+
+    equipmentSets:OnInitialize()
+  end)
+
+  -- ─── Update (version gating) ──────────────────────────────────────────────────
+
+  describe("Update", function()
+
+    it("returns early on classic", function()
+      addon.isClassic = true
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() error("should not be called") end
+      equipmentSets:Update()
+    end)
+
+    it("returns early on anniversary", function()
+      addon.isAnniversary = true
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() error("should not be called") end
+      equipmentSets:Update()
+    end)
+
+    it("calls UpdatePreMidnight when not midnight", function()
+      addon.isMidnight = false
+      equipmentSets:Update()
+    end)
+
+    it("calls UpdateMidnight when on midnight", function()
+      addon.isMidnight = true
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function(id) return "Set" .. id end
+      _G.C_EquipmentSet.GetItemLocations = function(id) return {"loc-" .. id} end
+      _G.EquipmentManager_GetLocationData = function()
+        return { isBank = false, isBags = true, slot = 1, bag = 0 }
+      end
+      equipmentSets:Update()
+      local result = equipmentSets:GetItemSets(0, 1)
+      assert.is_not_nil(result)
+      assert.are.same({"Set1"}, result)
+    end)
+  end)
+
+  -- ─── UpdatePreMidnight ────────────────────────────────────────────────────────
+
+  describe("UpdatePreMidnight", function()
+
+    it("maps equipment set items to bagAndSlotToSet", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1, 2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function(id) -- luacheck: ignore 212
+        if id == 1 then return "Tank Set" else return "DPS Set" end
+      end
+      _G.C_EquipmentSet.GetItemLocations = function(id) -- luacheck: ignore 212
+        return {"loc-" .. id .. "-a", "loc-" .. id .. "-b"}
+      end
+      _G.EquipmentManager_UnpackLocation = function(loc) -- luacheck: ignore 212
+        if loc == "loc-1-a" then return 0, false, true, false, 1, 0 end
+        if loc == "loc-1-b" then return 0, false, true, false, 2, 0 end
+        if loc == "loc-2-a" then return 0, false, true, false, 1, 0 end
+        if loc == "loc-2-b" then return 0, false, true, false, 3, 0 end
+        return 0, false, false, false, 0, 0
+      end
+
+      equipmentSets:UpdatePreMidnight()
+
+      local sets1 = equipmentSets:GetItemSets(0, 1)
+      assert.are.same({"Tank Set", "DPS Set"}, sets1)
+      assert.are.same({"Tank Set"}, equipmentSets:GetItemSets(0, 2))
+      assert.are.same({"DPS Set"}, equipmentSets:GetItemSets(0, 3))
+    end)
+
+    it("handles nil setLocations (bugfix for #113)", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1, 2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function(id) return "Set" .. id end -- luacheck: ignore 212
+      _G.C_EquipmentSet.GetItemLocations = function(id) -- luacheck: ignore 212
+        if id == 1 then return nil end
+        return {"loc-2"}
+      end
+      _G.EquipmentManager_UnpackLocation = function()
+        return 0, false, true, false, 1, 0
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      assert.are.same({"Set2"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("filters out non-bag/non-bank locations", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"loc-good", "loc-bad"} end
+      _G.EquipmentManager_UnpackLocation = function(loc) -- luacheck: ignore 212
+        if loc == "loc-good" then return 0, false, true, false, 1, 0 end
+        if loc == "loc-bad" then return 0, false, false, false, 1, 0 end
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      assert.are.same({"Set1"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("shifts slots for non-retail (no void bank)", function()
+      addon.isRetail = false
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Classic Set" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"loc-1"} end
+      _G.EquipmentManager_UnpackLocation = function()
+        return 0, false, true, 3, 5, 0
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      local result = equipmentSets:GetItemSets(5, 3)
+      assert.are.same({"Classic Set"}, result)
+    end)
+
+    it("skips locations with nil slot or nil bag", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function()
+        return {"loc-nil-slot", "loc-nil-bag", "loc-good"}
+      end
+      _G.EquipmentManager_UnpackLocation = function(loc) -- luacheck: ignore 212
+        if loc == "loc-nil-slot" then return 0, false, true, nil, nil, 0 end
+        if loc == "loc-nil-bag" then return 0, false, true, false, 1, nil end
+        if loc == "loc-good" then return 0, false, true, false, 1, 0 end
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      assert.are.same({"Set1"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("handles empty equipment set IDs", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {} end
+      equipmentSets:UpdatePreMidnight()
+      assert.is_nil(equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("clears previous state on each update", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"loc-1"} end
+      _G.EquipmentManager_UnpackLocation = function()
+        return 0, false, true, false, 1, 0
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      assert.are.same({"Set1"}, equipmentSets:GetItemSets(0, 1))
+
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set2" end
+      equipmentSets:UpdatePreMidnight()
+
+      assert.are.same({"Set2"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("includes bank locations", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Bank Set" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"loc-bank"} end
+      _G.EquipmentManager_UnpackLocation = function()
+        return 0, true, false, false, 5, 1
+      end
+
+      equipmentSets:UpdatePreMidnight()
+      assert.are.same({"Bank Set"}, equipmentSets:GetItemSets(1, 5))
+    end)
+  end)
+
+  -- ─── UpdateMidnight ───────────────────────────────────────────────────────────
+
+  describe("UpdateMidnight", function()
+
+    it("maps equipment set items using GetLocationData", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1, 2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function(id) -- luacheck: ignore 212
+        if id == 1 then return "Midnight Set A" else return "Midnight Set B" end
+      end
+      _G.C_EquipmentSet.GetItemLocations = function(id) -- luacheck: ignore 212
+        return {"mloc-" .. id .. "-1", "mloc-" .. id .. "-2"}
+      end
+      _G.EquipmentManager_GetLocationData = function(loc) -- luacheck: ignore 212
+        if loc == "mloc-1-1" then return { isBank = false, isBags = true, slot = 1, bag = 0 } end
+        if loc == "mloc-1-2" then return { isBank = false, isBags = true, slot = 2, bag = 0 } end
+        if loc == "mloc-2-1" then return { isBank = false, isBags = true, slot = 1, bag = 0 } end
+        if loc == "mloc-2-2" then return { isBank = true, isBags = false, slot = 3, bag = 2 } end
+        return { isBank = false, isBags = false, slot = 0, bag = 0 }
+      end
+
+      equipmentSets:UpdateMidnight()
+
+      assert.are.same({"Midnight Set A", "Midnight Set B"}, equipmentSets:GetItemSets(0, 1))
+      assert.are.same({"Midnight Set A"}, equipmentSets:GetItemSets(0, 2))
+      assert.are.same({"Midnight Set B"}, equipmentSets:GetItemSets(2, 3))
+    end)
+
+    it("handles nil setLocations", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1, 2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function(id) return "Set" .. id end -- luacheck: ignore 212
+      _G.C_EquipmentSet.GetItemLocations = function(id) -- luacheck: ignore 212
+        if id == 1 then return nil end
+        return {"mloc-2"}
+      end
+      _G.EquipmentManager_GetLocationData = function()
+        return { isBank = false, isBags = true, slot = 1, bag = 0 }
+      end
+
+      equipmentSets:UpdateMidnight()
+      assert.are.same({"Set2"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("filters out non-bag, non-bank locations", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"mloc-equip"} end
+      _G.EquipmentManager_GetLocationData = function()
+        return { isBank = false, isBags = false, slot = 5, bag = 0 }
+      end
+
+      equipmentSets:UpdateMidnight()
+      assert.is_nil(equipmentSets:GetItemSets(0, 5))
+    end)
+
+    it("skips locations with nil slot or nil bag", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function()
+        return {"mloc-nil-slot", "mloc-good"}
+      end
+      _G.EquipmentManager_GetLocationData = function(loc) -- luacheck: ignore 212
+        if loc == "mloc-nil-slot" then return { isBank = false, isBags = true, slot = nil, bag = 0 } end
+        if loc == "mloc-good" then return { isBank = false, isBags = true, slot = 1, bag = 0 } end
+      end
+
+      equipmentSets:UpdateMidnight()
+      assert.are.same({"Set1"}, equipmentSets:GetItemSets(0, 1))
+    end)
+
+    it("clears previous state on each update", function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set1" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"mloc-1"} end
+      _G.EquipmentManager_GetLocationData = function()
+        return { isBank = false, isBags = true, slot = 1, bag = 0 }
+      end
+
+      equipmentSets:UpdateMidnight()
+      assert.are.same({"Set1"}, equipmentSets:GetItemSets(0, 1))
+
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {2} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Set2" end
+      equipmentSets:UpdateMidnight()
+
+      assert.are.same({"Set2"}, equipmentSets:GetItemSets(0, 1))
+    end)
+  end)
+
+  -- ─── GetItemSets ──────────────────────────────────────────────────────────────
+
+  describe("GetItemSets", function()
+
+    before_each(function()
+      _G.C_EquipmentSet.GetEquipmentSetIDs = function() return {1} end
+      _G.C_EquipmentSet.GetEquipmentSetInfo = function() return "Test Set" end
+      _G.C_EquipmentSet.GetItemLocations = function() return {"loc-1"} end
+      _G.EquipmentManager_UnpackLocation = function()
+        return 0, false, true, false, 1, 0
+      end
+      equipmentSets:UpdatePreMidnight()
+    end)
+
+    it("returns set names for a valid bag/slot", function()
+      local sets = equipmentSets:GetItemSets(0, 1)
+      assert.are.same({"Test Set"}, sets)
+    end)
+
+    it("returns nil for nil bagid", function()
+      assert.is_nil(equipmentSets:GetItemSets(nil, 1))
+    end)
+
+    it("returns nil for nil slotid", function()
+      assert.is_nil(equipmentSets:GetItemSets(0, nil))
+    end)
+
+    it("returns nil for non-existent bag/slot combination", function()
+      assert.is_nil(equipmentSets:GetItemSets(99, 99))
+    end)
+
+    it("returns nil for valid bag but invalid slot", function()
+      assert.is_nil(equipmentSets:GetItemSets(0, 99))
+    end)
+  end)
+end)

--- a/spec/helpers/addon_loader.lua
+++ b/spec/helpers/addon_loader.lua
@@ -36,3 +36,20 @@ _G.StubBetterBagsModule = function(name)
   if ok and mod then return mod end
   return addon:NewModule(name)
 end
+
+--- Clear a previously-stubbed module so the real module file can be loaded safely.
+--- Only clears if the module exists and the real file hasn't been loaded yet.
+---@param name string Module name (e.g. "Database")
+---@param filePath string File path that would load the real module (e.g. "core/database.lua")
+_G.ResetModuleStub = function(name, filePath)
+  if loadedModules[filePath] then return end
+  if addon.modules[name] then
+    addon.modules[name] = nil
+  end
+  -- AceAddon registers modules as sub-addons via NewAddon with name "ParentName_ModuleName"
+  local subAddonName = "BetterBags_" .. name
+  local aceAddon = LibStub("AceAddon-3.0")
+  if aceAddon.addons[subAddonName] then
+    aceAddon.addons[subAddonName] = nil
+  end
+end

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -144,3 +144,19 @@ _G.wipe = function(t)
   end
   return t
 end
+
+-- Equipment set API
+_G.C_EquipmentSet = {
+  GetEquipmentSetIDs = function() return {} end,
+  GetEquipmentSetInfo = function() return "" end,
+  GetItemLocations = function() return {} end,
+}
+
+-- Equipment location unpack helpers
+_G.EquipmentManager_UnpackLocation = function()
+  return 0, false, true, false, 1, 0
+end
+
+_G.EquipmentManager_GetLocationData = function()
+  return { isBank = false, isBags = true, slot = 1, bag = 0 }
+end

--- a/spec/refresh_spec.lua
+++ b/spec/refresh_spec.lua
@@ -1,0 +1,379 @@
+-- refresh_spec.lua -- Unit tests for data/refresh.lua
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+addon.isRetail = true
+addon.isClassic = false
+addon.isAnniversary = false
+addon.atBank = false
+addon.atWarbank = false
+
+-- Mock Bags structure (simplified)
+addon.Bags = {
+  Backpack = { Draw = function() end },
+  Bank = nil,
+}
+
+-- Dependencies
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+
+local context = addon:GetModule("Context")
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+-- Constants stub
+local const = StubBetterBagsModule("Constants")
+const.BAG_KIND = { BACKPACK = 0, BANK = 1 }
+const.BANK_TAB = { ACCOUNT_BANK_1 = 200 }
+
+-- Debug stub
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+debug.Inspect = function() end
+
+-- Required globals for refresh module
+_G.Enum = _G.Enum or {}
+_G.Enum.BagIndex = _G.Enum.BagIndex or {}
+_G.Enum.BagIndex.AccountBankTab_1 = 200
+_G.Enum.BankType = _G.Enum.BankType or { Character = 1, Account = 2 }
+
+-- Items stub
+local items = StubBetterBagsModule("Items")
+local itemsCalls = {}
+items.GetAllSlotInfo = function() return {} end
+items.RefreshBackpack = function() end
+items.RefreshBank = function() end
+items.ClearItemCache = function() table.insert(itemsCalls, "ClearItemCache") end
+items.RemoveNewItemFromAllItems = function() table.insert(itemsCalls, "RemoveNewItemFromAllItems") end
+items.Restack = function(_, _, _, cb)
+  table.insert(itemsCalls, "Restack")
+  if cb then cb() end
+end
+
+-- Override C_Timer.NewTimer so we can control debounce timing
+local timerCallbacks = {}
+_G.C_Timer.NewTimer = function(seconds, callback)
+  local timer = { _seconds = seconds, _callback = callback }
+  table.insert(timerCallbacks, timer)
+  return {
+    Cancel = function(self)
+      timer._cancelled = true
+    end,
+  }
+end
+
+-- Helper to flush debounce timers
+local function flushTimers()
+  for _, timer in ipairs(timerCallbacks) do
+    if not timer._cancelled then
+      timer._callback()
+    end
+  end
+  for i = #timerCallbacks, 1, -1 do
+    timerCallbacks[i] = nil
+  end
+end
+
+-- Override C_Timer.After for AfterSort
+local afterCallbacks = {}
+_G.C_Timer.After = function(seconds, callback)
+  table.insert(afterCallbacks, {seconds = seconds, callback = callback})
+end
+
+local function flushAfters()
+  for _, ac in ipairs(afterCallbacks) do
+    ac.callback()
+  end
+  for i = #afterCallbacks, 1, -1 do
+    afterCallbacks[i] = nil
+  end
+end
+
+-- Reset InCombatLockdown
+
+LoadBetterBagsModule("data/refresh.lua")
+local refresh = addon:GetModule("Refresh")
+
+describe("Refresh", function()
+
+  before_each(function()
+    -- Reset items calls
+    for i = #itemsCalls, 1, -1 do itemsCalls[i] = nil end
+    -- Reset timers
+    for i = #timerCallbacks, 1, -1 do timerCallbacks[i] = nil end
+    for i = #afterCallbacks, 1, -1 do afterCallbacks[i] = nil end
+    -- Reset addon state
+    addon.atBank = false
+    addon.atWarbank = false
+    addon.Bags.Bank = nil
+    -- Reset combat state
+    _G.InCombatLockdown = function() return false end
+    -- Re-initialize module
+    refresh:OnInitialize()
+    events:OnInitialize()
+  end)
+
+  -- ─── OnInitialize ──────────────────────────────────────────────────────────────
+
+  describe("OnInitialize", function()
+
+    it("sets initial state", function()
+      refresh:OnInitialize()
+      assert.is_false(refresh.pendingBackpack)
+      assert.is_false(refresh.pendingBank)
+      assert.is_false(refresh.pendingWipe)
+      assert.is_nil(refresh.debounceTimer)
+      assert.is_false(refresh.isSorting)
+    end)
+  end)
+
+  -- ─── RequestUpdate ─────────────────────────────────────────────────────────────
+
+  describe("RequestUpdate", function()
+
+    it("sets pendingBackpack when request.backpack is true", function()
+      refresh:RequestUpdate({ backpack = true })
+      assert.is_true(refresh.pendingBackpack)
+    end)
+
+    it("sets pendingBank when request.bank is true", function()
+      refresh:RequestUpdate({ bank = true })
+      assert.is_true(refresh.pendingBank)
+    end)
+
+    it("sets pendingWipe when request.wipe is true", function()
+      refresh:RequestUpdate({ wipe = true })
+      assert.is_true(refresh.pendingWipe)
+    end)
+
+    it("sets multiple flags at once", function()
+      refresh:RequestUpdate({ wipe = true, backpack = true, bank = true })
+      assert.is_true(refresh.pendingWipe)
+      assert.is_true(refresh.pendingBackpack)
+      assert.is_true(refresh.pendingBank)
+    end)
+
+    it("does not set flags when sorting", function()
+      refresh.isSorting = true
+      refresh:RequestUpdate({ backpack = true })
+      assert.is_false(refresh.pendingBackpack)
+    end)
+
+    it("creates a debounce timer", function()
+      refresh:RequestUpdate({ backpack = true })
+      assert.is_not_nil(refresh.debounceTimer)
+      assert.are.equal(1, #timerCallbacks)
+    end)
+
+    it("cancels previous debounce timer on new request", function()
+      refresh:RequestUpdate({ backpack = true })
+      local firstTimer = timerCallbacks[1]
+      refresh:RequestUpdate({ bank = true })
+      assert.is_true(firstTimer._cancelled)
+    end)
+
+    it("cancels debounce timer when sort request arrives", function()
+      _G.InCombatLockdown = function() return false end
+      refresh:RequestUpdate({ backpack = true })
+      local updateTimer = timerCallbacks[1]
+      -- Sort should cancel the pending update timer before starting
+      refresh:RequestUpdate({ sort = true })
+      -- BUG: sort returns at line 97 before reaching the timer cancel at line 101,
+      -- so the update timer is still alive and will fire during sort
+      assert.is_true(updateTimer._cancelled, "debounce timer should be cancelled when sort starts")
+    end)
+
+    it("handles sort request when not in combat", function()
+      _G.InCombatLockdown = function() return false end
+      refresh:RequestUpdate({ sort = true })
+      assert.is_true(refresh.isSorting)
+      -- Should have called RemoveNewItemFromAllItems
+      local foundRemove = false
+      for _, call in ipairs(itemsCalls) do
+        if call == "RemoveNewItemFromAllItems" then foundRemove = true end
+      end
+      assert.is_true(foundRemove)
+      -- Should have called Restack
+      local foundRestack = false
+      for _, call in ipairs(itemsCalls) do
+        if call == "Restack" then foundRestack = true end
+      end
+      assert.is_true(foundRestack)
+    end)
+
+    it("ignores sort request in combat", function()
+      _G.InCombatLockdown = function() return true end
+      refresh:RequestUpdate({ sort = true })
+      assert.is_false(refresh.isSorting)
+    end)
+
+    it("does not queue update during sort", function()
+      refresh.isSorting = true
+      refresh:RequestUpdate({ wipe = true, backpack = true })
+      assert.is_false(refresh.pendingWipe)
+      assert.is_false(refresh.pendingBackpack)
+    end)
+  end)
+
+  -- ─── AfterSort ─────────────────────────────────────────────────────────────────
+
+  describe("AfterSort", function()
+
+    it("sets isSorting to false", function()
+      refresh.isSorting = true
+      refresh:AfterSort(context:New("Test"))
+      -- AfterSort schedules via C_Timer.After, flush the callback
+      flushAfters()
+      assert.is_false(refresh.isSorting)
+    end)
+
+    it("sends FullRefreshAll after delay", function()
+      local fullRefreshSent = false
+      events:RegisterMessage("bags/FullRefreshAll", function()
+        fullRefreshSent = true
+      end)
+
+      refresh:AfterSort(context:New("Test"))
+      -- Flush the C_Timer.After callback
+      flushAfters()
+
+      assert.is_true(fullRefreshSent)
+    end)
+  end)
+
+  -- ─── ExecutePendingUpdates ─────────────────────────────────────────────────────
+
+  describe("ExecutePendingUpdates", function()
+
+    it("clears pending flags on combat with pendingWipe", function()
+      _G.InCombatLockdown = function() return true end
+      refresh.pendingWipe = true
+      refresh.pendingBackpack = true
+      refresh.pendingBank = true
+      refresh:ExecutePendingUpdates()
+      assert.is_false(refresh.pendingWipe)
+      assert.is_false(refresh.pendingBackpack)
+      assert.is_false(refresh.pendingBank)
+    end)
+
+    it("clears item cache when pendingWipe", function()
+      _G.InCombatLockdown = function() return false end
+      refresh.pendingWipe = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+      local found = false
+      for _, call in ipairs(itemsCalls) do
+        if call == "ClearItemCache" then found = true end
+      end
+      assert.is_true(found)
+    end)
+
+    it("triggers backpack refresh after wipe via ClearItemCache", function()
+      _G.InCombatLockdown = function() return false end
+      refresh.pendingWipe = true
+      refresh:ExecutePendingUpdates()
+      -- ExecutePendingUpdates resets flags at the end, but ClearItemCache should have been called
+      local foundClearCache = false
+      for _, call in ipairs(itemsCalls) do
+        if call == "ClearItemCache" then foundClearCache = true end
+      end
+      assert.is_true(foundClearCache)
+      -- All flags reset after execution
+      assert.is_false(refresh.pendingWipe)
+      assert.is_false(refresh.pendingBackpack)
+      assert.is_false(refresh.pendingBank)
+    end)
+
+    it("updates bank when at bank", function()
+      _G.InCombatLockdown = function() return false end
+      addon.atBank = true
+      addon.Bags.Bank = { bankTab = 100 }
+      refresh.pendingBank = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+      -- Bank refresh should have been called (via debounce)
+      assert.is_false(refresh.pendingBank)
+    end)
+
+    it("updates backpack when pendingBackpack", function()
+      _G.InCombatLockdown = function() return false end
+      refresh.pendingBackpack = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+      assert.is_false(refresh.pendingBackpack)
+    end)
+
+    it("resets all pending flags after execution", function()
+      _G.InCombatLockdown = function() return false end
+      refresh.pendingBackpack = true
+      refresh.pendingBank = true
+      refresh.pendingWipe = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+      assert.is_false(refresh.pendingBackpack)
+      assert.is_false(refresh.pendingBank)
+      assert.is_false(refresh.pendingWipe)
+    end)
+
+    it("shifts bank tab to account bank start when at warbank", function()
+      _G.InCombatLockdown = function() return false end
+      addon.atBank = true
+      addon.atWarbank = true
+      addon.isRetail = true
+      addon.Bags.Bank = { bankTab = 50 } -- Below account bank start
+
+      refresh.pendingBank = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+
+      -- Bank tab should have been shifted to account bank start (200)
+      assert.are.equal(200, addon.Bags.Bank.bankTab)
+    end)
+
+    it("does not update bank when not at bank", function()
+      _G.InCombatLockdown = function() return false end
+      addon.atBank = false
+      refresh.pendingBank = true
+      refresh:ExecutePendingUpdates()
+      flushTimers()
+      assert.is_false(refresh.pendingBank)
+    end)
+
+    it("does nothing when no flags are set", function()
+      _G.InCombatLockdown = function() return false end
+      refresh:ExecutePendingUpdates()
+      -- Should complete without error
+    end)
+  end)
+
+  -- ─── RedrawBackpack ────────────────────────────────────────────────────────────
+
+  describe("RedrawBackpack", function()
+
+    it("calls Bags.Backpack:Draw with slot info", function()
+      local drawn = false
+      addon.Bags.Backpack.Draw = function(_, _, _, callback)
+        drawn = true
+        if callback then callback() end
+      end
+
+      refresh:RedrawBackpack(context:New("Test"))
+      assert.is_true(drawn)
+    end)
+
+    it("sends bags/Draw/Backpack/Done message on complete", function()
+      local doneReceived = false
+      events:RegisterMessage("bags/Draw/Backpack/Done", function()
+        doneReceived = true
+      end)
+
+      addon.Bags.Backpack.Draw = function(_, _, _, callback)
+        if callback then callback() end
+      end
+
+      refresh:RedrawBackpack(context:New("Test"))
+      assert.is_true(doneReceived)
+    end)
+  end)
+end)

--- a/spec/resize_spec.lua
+++ b/spec/resize_spec.lua
@@ -1,0 +1,279 @@
+-- resize_spec.lua -- Unit tests for util/resize.lua
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+StubBetterBagsModule("Constants")
+StubBetterBagsModule("Localization")
+
+-- Enhanced CreateFrame mock that records calls and stores scripts
+
+local frameRegistry = {}
+
+local function spyCreateFrame(frameType, name, parent)
+  local scripts = {}
+  local calls = {}
+  local frame = {
+    _type = frameType,
+    _name = name,
+    _parent = parent,
+    _calls = calls,
+    _scripts = scripts,
+    SetScript = function(self, script, handler)
+      scripts[script] = handler
+      table.insert(calls, {method = "SetScript", args = {script}})
+    end,
+    Show = function() table.insert(calls, {method = "Show"}) end,
+    Hide = function() table.insert(calls, {method = "Hide"}) end,
+    RegisterEvent = function() end,
+    UnregisterEvent = function() end,
+    SetResizable = function(self, val)
+      table.insert(calls, {method = "SetResizable", args = {val}})
+    end,
+    SetResizeBounds = function(self, minW, minH)
+      table.insert(calls, {method = "SetResizeBounds", args = {minW, minH}})
+    end,
+    EnableMouse = function(self, val)
+      table.insert(calls, {method = "EnableMouse", args = {val}})
+    end,
+    SetPoint = function(self, point)
+      table.insert(calls, {method = "SetPoint", args = {point}})
+    end,
+    SetSize = function(self, w, h)
+      table.insert(calls, {method = "SetSize", args = {w, h}})
+    end,
+    SetNormalTexture = function(self, tex)
+      table.insert(calls, {method = "SetNormalTexture", args = {tex}})
+    end,
+    SetHighlightTexture = function(self, tex)
+      table.insert(calls, {method = "SetHighlightTexture", args = {tex}})
+    end,
+    SetPushedTexture = function(self, tex)
+      table.insert(calls, {method = "SetPushedTexture", args = {tex}})
+    end,
+    SetAlpha = function(self, alpha)
+      table.insert(calls, {method = "SetAlpha", args = {alpha}})
+    end,
+    GetParent = function() return parent end,
+    StartSizing = function(self, point)
+      table.insert(calls, {method = "StartSizing", args = {point}})
+    end,
+    StopMovingOrSizing = function(self, point)
+      table.insert(calls, {method = "StopMovingOrSizing", args = {point}})
+    end,
+  }
+  table.insert(frameRegistry, frame)
+  if name then _G[name] = frame end
+  return frame
+end
+
+_G.CreateFrame = spyCreateFrame
+
+LoadBetterBagsModule("util/resize.lua")
+local resize = addon:GetModule("Resize")
+
+describe("Resize", function()
+
+  --- Create a mock parent frame that records calls
+  local function mockParentFrame()
+    local calls = {}
+    return {
+      _calls = calls,
+      SetResizable = function(self, val)
+        table.insert(calls, {method = "SetResizable", args = {val}})
+      end,
+      SetResizeBounds = function(self, minW, minH)
+        table.insert(calls, {method = "SetResizeBounds", args = {minW, minH}})
+      end,
+      StartSizing = function(self, point)
+        table.insert(calls, {method = "StartSizing", args = {point}})
+      end,
+      StopMovingOrSizing = function(self, point)
+        table.insert(calls, {method = "StopMovingOrSizing", args = {point}})
+      end,
+    }
+  end
+
+  before_each(function()
+    -- Clear frame registry for test isolation
+    for i = #frameRegistry, 1, -1 do
+      frameRegistry[i] = nil
+    end
+  end)
+
+  describe("MakeResizable", function()
+
+    it("returns a Button frame", function()
+      local parent = mockParentFrame()
+      local handle = resize:MakeResizable(parent, function() end)
+      assert.is_not_nil(handle)
+      assert.are.equal("Button", handle._type)
+    end)
+
+    it("calls SetResizable(true) on the parent frame", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      -- Verify SetResizable was called on parent
+      local hasSetResizable = false
+      for _, c in ipairs(parent._calls) do
+        if c.method == "SetResizable" then
+          assert.are.same({true}, c.args)
+          hasSetResizable = true
+        end
+      end
+      assert.is_true(hasSetResizable)
+    end)
+
+    it("calls SetResizeBounds(300, 300) on the parent frame", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local hasSetBounds = false
+      for _, c in ipairs(parent._calls) do
+        if c.method == "SetResizeBounds" then
+          assert.are.same({300, 300}, c.args)
+          hasSetBounds = true
+        end
+      end
+      assert.is_true(hasSetBounds)
+    end)
+
+    it("creates handle at BOTTOMRIGHT with size 24x24", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local calls = handle._calls
+
+      local setPointCall = nil
+      local setSizeCall = nil
+      for _, c in ipairs(calls) do
+        if c.method == "SetPoint" then setPointCall = c end
+        if c.method == "SetSize" then setSizeCall = c end
+      end
+      assert.is_not_nil(setPointCall)
+      assert.are.same({"BOTTOMRIGHT"}, setPointCall.args)
+      assert.are.same({24, 24}, setSizeCall.args)
+    end)
+
+    it("sets up resize handle textures", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local calls = handle._calls
+
+      local hasNormalTex = false
+      local hasHighlightTex = false
+      local hasPushedTex = false
+      for _, c in ipairs(calls) do
+        if c.method == "SetNormalTexture" then hasNormalTex = true end
+        if c.method == "SetHighlightTexture" then hasHighlightTex = true end
+        if c.method == "SetPushedTexture" then hasPushedTex = true end
+      end
+      assert.is_true(hasNormalTex)
+      assert.is_true(hasHighlightTex)
+      assert.is_true(hasPushedTex)
+    end)
+
+    it("enables mouse on the resize handle", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local calls = handle._calls
+
+      local hasEnableMouse = false
+      for _, c in ipairs(calls) do
+        if c.method == "EnableMouse" then
+          assert.are.same({true}, c.args)
+          hasEnableMouse = true
+        end
+      end
+      assert.is_true(hasEnableMouse)
+    end)
+
+    it("starts with alpha 0 (hidden)", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local calls = handle._calls
+
+      local setAlphaCalled = false
+      for _, c in ipairs(calls) do
+        if c.method == "SetAlpha" then
+          setAlphaCalled = true
+        end
+      end
+      assert.is_true(setAlphaCalled)
+      -- Verify the initial SetAlpha(0) happened
+      assert.are.same({0}, calls[#calls].args)
+    end)
+
+    -- ─── Script wiring ──────────────────────────────────────────────────────────
+
+    it("wires OnEnter to set alpha to 1", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local scripts = handle._scripts
+
+      assert.is_not_nil(scripts["OnEnter"])
+      scripts["OnEnter"](handle)
+      local setAlphaCalls = {}
+      for _, c in ipairs(handle._calls) do
+        if c.method == "SetAlpha" then table.insert(setAlphaCalls, c) end
+      end
+      assert.are.same({1}, setAlphaCalls[#setAlphaCalls].args)
+    end)
+
+    it("wires OnLeave to set alpha to 0", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local scripts = handle._scripts
+
+      assert.is_not_nil(scripts["OnLeave"])
+      scripts["OnLeave"](handle)
+      local setAlphaCalls = {}
+      for _, c in ipairs(handle._calls) do
+        if c.method == "SetAlpha" then table.insert(setAlphaCalls, c) end
+      end
+      assert.are.same({0}, setAlphaCalls[#setAlphaCalls].args)
+    end)
+
+    it("wires OnMouseDown to start sizing on the parent", function()
+      local parent = mockParentFrame()
+      resize:MakeResizable(parent, function() end)
+      local handle = frameRegistry[1]
+      local scripts = handle._scripts
+
+      assert.is_not_nil(scripts["OnMouseDown"])
+      scripts["OnMouseDown"](handle)
+      -- StartSizing is called on the parent frame (p:GetParent())
+      local startSizingCalls = {}
+      for _, c in ipairs(parent._calls) do
+        if c.method == "StartSizing" then table.insert(startSizingCalls, c) end
+      end
+      assert.are.equal(1, #startSizingCalls)
+      assert.are.same({"BOTTOMRIGHT"}, startSizingCalls[1].args)
+    end)
+
+    it("wires OnMouseUp to stop sizing on the parent and call onDone", function()
+      local parent = mockParentFrame()
+      local doneCalled = false
+      local onDone = function() doneCalled = true end
+      resize:MakeResizable(parent, onDone)
+      local handle = frameRegistry[1]
+      local scripts = handle._scripts
+
+      assert.is_not_nil(scripts["OnMouseUp"])
+      scripts["OnMouseUp"](handle)
+
+      -- StopMovingOrSizing is called on the parent frame
+      local stopCalls = {}
+      for _, c in ipairs(parent._calls) do
+        if c.method == "StopMovingOrSizing" then table.insert(stopCalls, c) end
+      end
+      assert.are.equal(1, #stopCalls)
+      assert.are.same({"BOTTOMRIGHT"}, stopCalls[1].args)
+
+      assert.is_true(doneCalled)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

Adds 192 new tests across 5 new spec files, bringing the total to 692 tests (0 failures, 0 luacheck warnings).

### New Spec Files

| Spec | Tests | Module Covered |
|------|-------|----------------|
| \`equipmentsets_spec.lua\` | 22 | Equipment set → bag/slot indexing, version gating, GetItemSets |
| \`resize_spec.lua\` | 11 | Resize handle creation, script wiring |
| \`database_spec.lua\` | 135 | Getters/setters, categories, groups, profiles, import/export |
| \`database_migration_spec.lua\` | 4 | Migrate() edge cases |
| \`refresh_spec.lua\` | 24 | RequestUpdate state machine, debounce, sort, combat gating |

### Infrastructure

- **\`wow_mocks.lua\`**: Added \`C_EquipmentSet\`, \`EquipmentManager_UnpackLocation\`, \`EquipmentManager_GetLocationData\`
- **\`addon_loader.lua\`**: Added \`ResetModuleStub()\` to safely clear stubbed modules before loading real ones (resolves spec ordering conflicts)
- **\`.luacheckrc\`**: Added \`ResetModuleStub\` global, ignored W212 for spec files

### Bug Fixes

- **\`core/database.lua:1021\`**: Fixed operator precedence crash — \`nil itemsPerRow\` would cause \`attempt to compare nil with number\` due to missing parentheses
- **\`data/refresh.lua:90-98\`**: Fixed leaked debounce timer — sort requests returned before cancelling pending update timers, causing \`ExecutePendingUpdates\` to fire during active sort