### PR TITLE
ci: track test coverage with luacov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,21 @@ jobs:
       - name: Install busted
         run: luarocks install busted
 
+      - name: Install luacov
+        run: luarocks install luacov
+
       - name: Run tests
-        run: busted
+        run: busted --coverage
+
+      - name: Generate coverage report
+        run: luacov
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: luacov-report
+          path: |
+            luacov.report.out
+            luacov.stats.out
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cpp-ghost-text-preview-widget-anysphere://**
 /.libraries/**
 /logs/**
 /.omc/**
+/luacov.report.out
+/luacov.stats.out

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,29 @@
+return {
+  default = {
+    -- Code to include in coverage analysis. luacov only reports coverage for
+    -- files actually loaded via require/dofile, so this list is a hint for
+    -- which package.path roots to look up -- not a filter on output.
+    include = {
+      "util",
+      "core",
+      "data",
+      "animations",
+      "integrations",
+      "themes",
+    },
+
+    -- Code to exclude from the coverage report. These are third-party
+    -- libraries and test code; we only want to measure our own source.
+    exclude = {
+      "spec",
+      "libs",
+      ".libraries",
+    },
+
+    -- Write report files into the project root (gitignored) so they don't
+    -- clutter the developer's HOME directory.
+    reportfile = "luacov.report.out",
+    statsfile  = "luacov.stats.out",
+    deletestats = false,
+  }
+}


### PR DESCRIPTION
Wire luacov into the test workflow so we can monitor coverage over time.

Adds:
- \`.luacov\`: project config for luacov. Includes source roots (util, core, data, animations, integrations, themes), excludes spec/, libs/, and .libraries/ (third-party and test code), and writes reports to the project root.
- \`.github/workflows/test.yml\`: installs luacov via luarocks, runs busted --coverage, generates the luacov report, and uploads it as a build artifact (luacov-report, retained 14 days).
- \`.gitignore\`: ignore the generated luacov.report.out and luacov.stats.out files.

To reproduce locally:
\`\`\`
busted --coverage
luacov
\`\`\`

Current coverage on main (727 tests): 25/33 source files exercised. Lowest uncovered: data/items.lua (22.6%), data/tooltip.lua (33.1%), data/categories.lua (34.5%), data/refresh.lua (35.3%). Files still at 0%: core/boot, core/constants, core/fonts, core/hooks, core/init, core/localization, core/overrides, core/translations (mostly trivial or require full addon environment).