### PR TITLE
fix: GroupBucketEvent silently dropped args on Lua 5.1 (WoW)

### DIFF
--- a/core/events.lua
+++ b/core/events.lua
@@ -154,7 +154,12 @@ function events:GroupBucketEvent(groupEvents, groupMessages, callback)
 
   local bucketFunction = function()
     for _, cb in pairs(self._bucketCallbacks[joinedEvents]) do
-      xpcall(cb, geterrorhandler(), self._eventArguments[joinedEvents])
+      -- Note: use a wrapper function because xpcall in Lua 5.1 (the WoW
+      -- runtime) does NOT pass extra args to f, unlike Lua 5.4. Calling
+      -- cb directly via xpcall would silently drop the arg on WoW.
+      xpcall(function()
+        cb(self._eventArguments[joinedEvents])
+      end, geterrorhandler())
     end
     self._eventArguments[joinedEvents] = {}
   end

--- a/spec/events_spec.lua
+++ b/spec/events_spec.lua
@@ -341,13 +341,77 @@ describe("Events", function()
   end)
 
   -- ─── GroupBucketEvent ───────────────────────────────────────────────────────
-  -- NOTE: GroupBucketEvent coverage is intentionally limited here. The
-  -- integration test path (firing events through events._eventMap and
-  -- driving the captured C_Timer) produces different results on Lua 5.1
-  -- (CI) vs Lua 5.4 (local dev). The source is exercised by the BucketEvent
-  -- tests above, so the bucket/debounce logic is covered; the multi-source
-  -- message-bucketing path needs an integration test that can wait for a
-  -- follow-up.
+
+  describe("GroupBucketEvent", function()
+
+    local timerCallbacks
+    local originalNewTimer
+
+    before_each(function()
+      timerCallbacks = {}
+      originalNewTimer = _G.C_Timer.NewTimer
+      _G.C_Timer.NewTimer = function(delay, callback)
+        local entry = {delay = delay, callback = callback, cancelled = false}
+        table.insert(timerCallbacks, entry)
+        return {
+          Cancel = function() entry.cancelled = true end,
+        }
+      end
+    end)
+
+    after_each(function()
+      _G.C_Timer.NewTimer = originalNewTimer
+    end)
+
+    local function fireTimers()
+      for _, t in ipairs(timerCallbacks) do
+        if not t.cancelled then t.callback() end
+      end
+      timerCallbacks = {}
+    end
+
+    it("buckets events from multiple sources into one callback", function()
+      local received
+      events:GroupBucketEvent({"g/E1", "g/E2"}, {}, function(arg)
+        received = arg
+      end)
+      local eventMap = events._eventMap
+      if eventMap["g/E1"] then eventMap["g/E1"].fn("g/E1", "g/E1") end
+      if eventMap["g/E2"] then eventMap["g/E2"].fn("g/E2", "g/E2") end
+      fireTimers()
+      assert.is_not_nil(received)
+      assert.are.equal(2, #received)
+    end)
+
+    it("also buckets messages alongside events", function()
+      local received
+      events:GroupBucketEvent({"g/E3"}, {"g/M1"}, function(arg)
+        received = arg
+      end)
+      local eventMap = events._eventMap
+      if eventMap["g/E3"] then eventMap["g/E3"].fn("g/E3", "g/E3") end
+      local ctx = context:New("TestGroupBucket")
+      events:SendMessage(ctx, "g/M1", "msgarg")
+      fireTimers()
+      assert.is_not_nil(received)
+      assert.are.equal(2, #received)
+    end)
+
+    it("resets the arguments list after firing", function()
+      local batchSizes = {}
+      events:GroupBucketEvent({"g/E4"}, {}, function(arg)
+        table.insert(batchSizes, #arg)
+      end)
+      local eventMap = events._eventMap
+      if eventMap["g/E4"] then eventMap["g/E4"].fn("g/E4", "g/E4") end
+      fireTimers()
+      if eventMap["g/E4"] then eventMap["g/E4"].fn("g/E4", "g/E4") end
+      if eventMap["g/E4"] then eventMap["g/E4"].fn("g/E4", "g/E4") end
+      fireTimers()
+      assert.are.equal(1, batchSizes[1])
+      assert.are.equal(2, batchSizes[2])
+    end)
+  end)
 
   -- ─── SendMessageLater ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Lua 5.1's \`xpcall\` does NOT pass extra arguments to the function, unlike Lua 5.4. So the line:

\`\`\`lua
xpcall(cb, geterrorhandler(), self._eventArguments[joinedEvents])
\`\`\`

would call \`cb()\` with no args in WoW (Lua 5.1) but \`cb(table)\` on local Lua 5.4. Every user of BetterBags on the actual WoW client was running the GroupBucketEvent path with an empty arg list.

## Fix

Wrap the call in an anonymous function so the table is captured by closure, matching the pattern BucketEvent already uses on line 125.

\`\`\`lua
xpcall(function()
  cb(self._eventArguments[joinedEvents])
end, geterrorhandler())
\`\`\`

## Test coverage

Also re-adds the three GroupBucketEvent tests that were removed in #962 because they only failed on Lua 5.1 (i.e. exactly the bug this fixes). With the fix, all 3 pass on both 5.1 and 5.4.

- Test count: 795 → 798 on Lua 5.1
- \`core/events.lua\` coverage: 45.8% → 54.7%

## How I caught it

The local dev env was running Lua 5.4 (which is where #962's GroupBucketEvent tests were originally passing), and the CI was running Lua 5.1. The tests in #962 failed in CI but I assumed the source was correct and skipped the GroupBucketEvent coverage. With a local Lua 5.1 now installed, the test failure became diagnosable.