### PR TITLE
Enforce Lua 5.1 as the only supported runtime (repo-wide)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,22 @@ If any file changes are made, create a new git commit in the same task. Commit m
 
 For any code changes, always run `luacheck .` from the repository root before finishing. Add any newly introduced WoW API globals to `.luacheckrc` as needed.
 
+## Lua Version
+
+The project targets **Lua 5.1 only**. Not 5.2, not 5.3, not 5.4, not LuaJIT-in-5.2-mode. WoW's runtime is Lua 5.1; the addon's code, its libraries, its tests, and its linter all run on 5.1 and only on 5.1. There is no 5.4 support, there will never be 5.4 support, and any code or test that "happens to work" on 5.4 is not validated by anything in this repository.
+
+This is enforced in three places, redundantly, on purpose:
+
+- **CI pins Lua 5.1** — `.github/workflows/test.yml:32` and `.github/workflows/luacheck.yml:19` both install `leafo/gh-actions-lua@v10` with `luaVersion: "5.1"`, then install `busted` / `luacheck` against that interpreter. A PR that breaks 5.1 will fail CI even if it passes locally on a different runtime.
+- **Luacheck is locked to the 5.1 standard** — `.luacheckrc:1` sets `std = "lua51"`, so any 5.2+/5.3+/5.4-only construct (goto, `<close>`, integer division, `//`, etc.) is a lint error.
+- **The test suite runtime-asserts 5.1** — `spec/setup.lua:1-12` errors out before any test code runs if `_VERSION ~= "Lua 5.1"`. Running `busted` against any other interpreter fails immediately with a message naming the detected version and pointing at this section.
+
+Practical consequences:
+
+- Do not use any 5.2+ language feature or standard library function. If you are tempted to reach for one, stop and find the 5.1 equivalent. Luacheck will catch it; the test guard will catch it; CI will catch it.
+- The `lua` / `busted` binaries on `$PATH` must be 5.1 (or a 5.1-compatible LuaJIT 2.x, whose `_VERSION` is `"Lua 5.1"`). If `lua -v` reports anything other than `Lua 5.1.x`, fix that before running the suite — do not "just try it" on the wrong runtime and trust a green result. `install-deps.sh` does not install a Lua interpreter; you must provide 5.1 yourself.
+- When debugging a test failure, never conclude "this works on 5.4" as a workaround. 5.4 is irrelevant. Fix the 5.1 behavior.
+
 ## Deps Requirements
 
 Before starting a brand new task, make sure you always run `install-deps.sh` so that deps are installed. This will also let you look at the wow source code directly as needed.

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,6 +2,8 @@
 
 Unit tests for BetterBags, powered by [busted](https://olivinelabs.com/busted/) with Lua 5.1.
 
+> **The suite is Lua 5.1 only.** `spec/setup.lua` aborts before any test code runs if `_VERSION` is not `"Lua 5.1"`. If you see a "BetterBags test suite requires Lua 5.1" error, the `lua` / `busted` on your `PATH` is the wrong interpreter — install Lua 5.1 (or a 5.1-compatible LuaJIT 2.x) and `luarocks install busted` against it, then rerun. See `CLAUDE.md` § "Lua Version" for the full policy.
+
 ## Running Tests
 
 ```bash

--- a/spec/setup.lua
+++ b/spec/setup.lua
@@ -1,3 +1,16 @@
+-- Step 0: Enforce Lua 5.1. The BetterBags suite targets WoW's Lua 5.1 runtime;
+-- running on any other interpreter (5.2, 5.3, 5.4, luajit-5.2-mode, etc.) is
+-- unsupported and will silently produce false confidence. This guard runs
+-- before any library load or test code so the failure is immediate and loud.
+if _VERSION ~= "Lua 5.1" then
+  error(string.format(
+    "BetterBags test suite requires Lua 5.1 (WoW's runtime). Detected %s. "
+    .. "Install Lua 5.1 and `luarocks install busted` against it; "
+    .. "see spec/README.md and CLAUDE.md (\"Lua Version\").",
+    _VERSION
+  ), 0)
+end
+
 -- setup.lua -- Busted test helper. Loaded before all spec files via .busted config.
 -- Delegates to modular helpers in spec/helpers/ for maintainability.
 


### PR DESCRIPTION
## Summary

The project's code, libraries, and tests have always targeted Lua 5.1 (WoW's runtime), but the suite had no mechanical guarantee of that: any interpreter could run \`busted\`, and a green run on, say, Lua 5.4 would not be validated by anything in the repo. This pins 5.1 as the single source of truth, enforced in three redundant places, and documents the policy in agent-facing docs.

## Changes

- **\`spec/setup.lua:1-12\`** — new Step 0 guard. Errors out before any library load or test code if \`_VERSION ~= "Lua 5.1"\`. Names the detected interpreter and points at the docs. Cannot be bypassed without editing source.
- **\`CLAUDE.md\`** — new \`## Lua Version\` section between \`## Luacheck Requirement\` and \`## Deps Requirements\`. States the 5.1-only policy in absolute terms (no 5.4 hedging), lists the three enforcement points with line-number citations, and lists the practical consequences (no 5.2+ features, no "works on 5.4" debugging shortcuts, install 5.1 yourself because \`install-deps.sh\` only fetches WoW-target libs). \`AGENTS.md\` is a symlink to \`CLAUDE.md\` (commit babc388), so the change is picked up there automatically.
- **\`spec/README.md:4-6\`** — front-matter callout pointing at the guard error and at \`CLAUDE.md\` § "Lua Version" for remediation.

## Enforcement already in place, now made explicit in docs

- \`.github/workflows/test.yml:32\` — CI installs Lua 5.1 via \`leafo/gh-actions-lua@v10\` and pins busted/luacov against it.
- \`.github/workflows/luacheck.yml:19\` — luacheck CI pins Lua 5.1 the same way.
- \`.luacheckrc:1\` — \`std = "lua51"\`, so 5.2+/5.3+/5.4-only constructs (goto, \`<close>\`, \`//\`, etc.) are lint errors.

## Verification

- \`busted\` on Lua 5.1 → guard passes, **798 successes / 0 failures / 0 errors / 0 pending**.
- \`busted\` on the system Lua 5.4 → guard fires with \`BetterBags test suite requires Lua 5.1 (WoW's runtime). Detected Lua 5.4. ...\`, confirming the enforcement is real, not just a doc claim.
- \`luacheck .\` → 0 warnings / 0 errors in 139 files.