### PR TITLE
Update Interface version TOC numbers across all versions

### DIFF
--- a/BetterBags.toc
+++ b/BetterBags.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 120001
+## Interface: 120007
 
 ## Title: BetterBags
 ## Category: Inventory

--- a/BetterBags_Mists.toc
+++ b/BetterBags_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50501
+## Interface: 50504
 
 ## Title: BetterBags
 ## Notes: Better Bags for everyone!

--- a/BetterBags_Vanilla.toc
+++ b/BetterBags_Vanilla.toc
@@ -1,4 +1,4 @@
-## Interface: 11507
+## Interface: 11508
 
 ## Title: BetterBags
 ## Notes: Better Bags for everyone!


### PR DESCRIPTION
Update the WoW interface TOC numbers to the latest release versions to prevent the client from marking the addon as out-of-date:
- **BetterBags.toc** (Retail / Midnight): Updated from 120000, 120001 to 120007 (Patch 12.0.7).
- **BetterBags_Vanilla.toc** (Classic Era / Vanilla): Updated from 11507 to 11508 (Patch 1.15.8).
- **BetterBags_Mists.toc** (Mists of Pandaria Classic): Updated from 50501 to 50504 (Patch 5.5.4).

BetterBags_TBC.toc is already on 20505 (Classic Anniversary TBC), which is the latest.