### PR TITLE
Fix four bugs in data stack (refresh, items, stacks, and categories)

### DIFF
--- a/data/categories.lua
+++ b/data/categories.lua
@@ -132,6 +132,8 @@ function categories:AddPermanentItemToCategory(ctx, id, category)
   assert(category ~= nil, format("Attempted to add item %d to a nil category.", id))
   assert(C_Item.GetItemInfoInstant(id), format("Attempted to add item %d to category %s, but the item does not exist.", id, category))
 
+  self.itemsWithNoCategory[id] = nil
+
   if not database:ItemCategoryExists(category) then
     self:CreateCategory(ctx, {
       name = category,
@@ -164,6 +166,8 @@ function categories:AddItemToCategory(ctx, id, category)
   assert(id, format("Attempted to add item to category %s, but the item ID is nil.", category))
   assert(category ~= nil, format("Attempted to add item %d to a nil category.", id))
   assert(C_Item.GetItemInfoInstant(id), format("Attempted to add item %d to category %s, but the item does not exist.", id, category))
+
+  self.itemsWithNoCategory[id] = nil
 
   -- Backwards compatability for the old way of adding items to categories.
   if not self.ephemeralCategories[category] then
@@ -586,6 +590,7 @@ end
 
 ---@param id number The ItemID of the item to remove from a custom category.
 function categories:RemoveItemFromCategory(id)
+  self.itemsWithNoCategory[id] = nil
   local filter = self.ephemeralCategoryByItemID[id]
   if filter then
     filter.itemList[id] = nil

--- a/data/items.lua
+++ b/data/items.lua
@@ -888,7 +888,7 @@ function items:LoadItems(ctx, kind, dataCache, equipmentCache, callback)
 				debug:Log("ItemChanged", "Bugged item detected during loading, skipping.")
 			else
 				slotInfo:AddToUpdatedItems(previousItem, currentItem)
-				search:Remove(currentItem)
+				search:Remove(previousItem)
 				search:Add(currentItem)
 			end
 		end

--- a/data/refresh.lua
+++ b/data/refresh.lua
@@ -117,11 +117,8 @@ end
 function refresh:ExecutePendingUpdates()
   local ctx = context:New('BagUpdate')
 
-  -- Prevent wipes during combat
-  if self.pendingWipe and InCombatLockdown() then
-    self.pendingBackpack = false
-    self.pendingBank = false
-    self.pendingWipe = false
+  -- Prevent updates during combat
+  if InCombatLockdown() then
     return
   end
 

--- a/data/stacks.lua
+++ b/data/stacks.lua
@@ -76,6 +76,7 @@ function stack:RemoveFromStack(item)
       stackinfo.count = stackinfo.count - 1
     else
       self.stacksByItemHash[item.itemHash] = nil
+      return
     end
   elseif stackinfo.slotkeys[item.slotkey] then
     stackinfo.slotkeys[item.slotkey] = nil

--- a/spec/categories_spec.lua
+++ b/spec/categories_spec.lua
@@ -434,4 +434,39 @@ describe("Categories", function()
       assert.is_nil(categories.ephemeralCategoryByItemID[42])
     end)
   end)
+
+  -- ─── GetCustomCategory ──────────────────────────────────────────────────────
+
+  describe("GetCustomCategory", function()
+
+    it("correctly clears itemsWithNoCategory cache after manual addition and removal", function()
+      local ctx = context:New("Test")
+      local itemID = 12345
+      local mockItem = { itemInfo = { itemID = itemID } }
+      local _
+
+      -- Ensure it starts with no custom category (returns nil)
+      -- This will populate the cache `self.itemsWithNoCategory[itemID] = true`
+      local categoryName, priority = categories:GetCustomCategory(ctx, const.BAG_KIND.BACKPACK, mockItem)
+      assert.is_nil(categoryName)
+      assert.is_nil(priority)
+      assert.is_true(categories.itemsWithNoCategory[itemID])
+
+      -- Add it to a custom category
+      categories:AddItemToCategory(ctx, itemID, "MyManualCategory")
+
+      -- Assert that itemsWithNoCategory cache is cleared for this item
+      assert.is_nil(categories.itemsWithNoCategory[itemID])
+
+      -- Query it again. It should now return the category name "MyManualCategory"
+      categoryName, _ = categories:GetCustomCategory(ctx, const.BAG_KIND.BACKPACK, mockItem)
+      assert.are.equal("MyManualCategory", categoryName)
+
+      -- Remove it from the custom category
+      categories:RemoveItemFromCategory(itemID)
+
+      -- Assert that itemsWithNoCategory cache is also cleared upon removal
+      assert.is_nil(categories.itemsWithNoCategory[itemID])
+    end)
+  end)
 end)

--- a/spec/frames/money_spec.lua
+++ b/spec/frames/money_spec.lua
@@ -1,0 +1,136 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Load required modules
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+-- Stub any missing dependencies
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+
+LoadBetterBagsModule("frames/money.lua")
+local money = addon:GetModule("MoneyFrame")
+
+describe("Money Frame", function()
+  before_each(function()
+    _G._playerMoney = 1234567 -- 123 gold, 45 silver, 67 copper
+    _G._depositedMoney = 9876543 -- 987 gold, 65 silver, 43 copper
+    _G._lastPopupShown = nil
+    _G.GameTooltip.lines = {}
+    _G.GameTooltip.doubleLines = {}
+  end)
+
+  describe("Creation and Initialization", function()
+    it("creates standard player money frame correctly", function()
+      local m = money:Create(false)
+      assert.is_not_nil(m)
+      assert.is_not_nil(m.frame)
+      assert.is_not_nil(m.overlay)
+      assert.is_false(m.warbank)
+      assert.are.equal(m.copperButton:GetText(), "67")
+      assert.are.equal(m.silverButton:GetText(), "45")
+      assert.are.equal(m.goldButton:GetText(), "123")
+    end)
+
+    it("creates warbank money frame correctly", function()
+      local m = money:Create(true)
+      assert.is_not_nil(m)
+      assert.is_true(m.warbank)
+      assert.are.equal(m.copperButton:GetText(), "43")
+      assert.are.equal(m.silverButton:GetText(), "65")
+      assert.are.equal(m.goldButton:GetText(), "987")
+    end)
+  end)
+
+  describe("Update Loop and Formatting", function()
+    it("updates copper/silver/gold dynamically when money changes", function()
+      local m = money:Create(false)
+      _G._playerMoney = 500020 -- 50 gold, 0 silver, 20 copper
+      m:Update()
+      assert.are.equal(m.goldButton:GetText(), "50")
+      assert.are.equal(m.silverButton:GetText(), "0")
+      assert.are.equal(m.copperButton:GetText(), "20")
+    end)
+
+    it("formats gold above 1000 with thousands separators", function()
+      local m = money:Create(false)
+      _G._playerMoney = 150000000 -- 15,000 gold
+      m:Update()
+      assert.are.equal(m.goldButton:GetText(), "15,000")
+    end)
+  end)
+
+  describe("Event updates", function()
+    it("responds to PLAYER_MONEY events", function()
+      local m = money:Create(false)
+      _G._playerMoney = 777777 -- 77 gold, 77 silver, 77 copper
+      events._eventMap["PLAYER_MONEY"].fn()
+      assert.are.equal(m.goldButton:GetText(), "77")
+      assert.are.equal(m.silverButton:GetText(), "77")
+      assert.are.equal(m.copperButton:GetText(), "77")
+    end)
+  end)
+
+  describe("Mouse Interactions and Popups", function()
+    it("shows PICKUP_MONEY popup on left-clicking standard frame", function()
+      local m = money:Create(false)
+      local onMouseDown = m.overlay:GetScript("OnMouseDown")
+      assert.is_not_nil(onMouseDown)
+      onMouseDown(m.overlay, "LeftButton")
+      assert.is_not_nil(_G._lastPopupShown)
+      assert.are.equal(_G._lastPopupShown.name, "PICKUP_MONEY")
+    end)
+
+    it("shows BANK_MONEY_WITHDRAW popup on left-clicking warbank frame", function()
+      local m = money:Create(true)
+      local onMouseDown = m.overlay:GetScript("OnMouseDown")
+      onMouseDown(m.overlay, "LeftButton")
+      assert.is_not_nil(_G._lastPopupShown)
+      assert.are.equal(_G._lastPopupShown.name, "BANK_MONEY_WITHDRAW")
+      assert.are.equal(_G._lastPopupShown.args[3].bankType, _G.Enum.BankType.Account)
+    end)
+
+    it("shows BANK_MONEY_DEPOSIT popup on right-clicking warbank frame", function()
+      local m = money:Create(true)
+      local onMouseDown = m.overlay:GetScript("OnMouseDown")
+      onMouseDown(m.overlay, "RightButton")
+      assert.is_not_nil(_G._lastPopupShown)
+      assert.are.equal(_G._lastPopupShown.name, "BANK_MONEY_DEPOSIT")
+      assert.are.equal(_G._lastPopupShown.args[3].bankType, _G.Enum.BankType.Account)
+    end)
+  end)
+
+  describe("Tooltip Interaction", function()
+    it("sets standard money tooltip correctly on OnEnter", function()
+      local m = money:Create(false)
+      local onEnter = m.overlay:GetScript("OnEnter")
+      assert.is_not_nil(onEnter)
+      onEnter()
+      assert.are.equal(_G.GameTooltip._owner, m.overlay)
+      assert.are.equal(#_G.GameTooltip.doubleLines, 1)
+      assert.are.equal(_G.GameTooltip.doubleLines[1].left, "Left Click")
+      assert.are.equal(_G.GameTooltip.doubleLines[1].right, "Pick up money")
+    end)
+
+    it("sets warbank money tooltip correctly on OnEnter", function()
+      local m = money:Create(true)
+      local onEnter = m.overlay:GetScript("OnEnter")
+      onEnter()
+      assert.are.equal(_G.GameTooltip._owner, m.overlay)
+      assert.are.equal(#_G.GameTooltip.doubleLines, 2)
+      assert.are.equal(_G.GameTooltip.doubleLines[1].left, "Left Click")
+      assert.are.equal(_G.GameTooltip.doubleLines[2].left, "Right Click")
+    end)
+
+    it("hides tooltip on OnLeave", function()
+      local m = money:Create(false)
+      local onLeave = m.overlay:GetScript("OnLeave")
+      assert.is_not_nil(onLeave)
+      onLeave()
+      assert.is_false(_G.GameTooltip._shown)
+    end)
+  end)
+end)

--- a/spec/frames/section_spec.lua
+++ b/spec/frames/section_spec.lua
@@ -1,0 +1,196 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Load required core modules
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("core/pool.lua")
+
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+-- Stub file-scope modules required by frames/section.lua
+local categories = StubBetterBagsModule("Categories")
+categories.GetGroupForCategory = function() return nil end
+
+local const = StubBetterBagsModule("Constants")
+const.BAG_VIEW = { SECTION_GRID = 1 }
+const.BAG_KIND = { BACKPACK = 1, BANK = 2 }
+const.MOVEMENT_FLOW = { UNDEFINED = 0, NPCSHOP = 1 }
+
+local sort = StubBetterBagsModule("Sort")
+sort.GetItemSortBySlot = function() end
+sort.GetItemSortFunction = function() end
+
+local database = StubBetterBagsModule("Database")
+database.GetShowFullSectionNames = function() return false end
+database.GetShowFullSectionNames = function() return false end
+database.ToggleSectionCollapsed = function() end
+
+local themes = StubBetterBagsModule("Themes")
+themes.UpdateSectionFont = function() end
+themes.RegisterSectionFont = function() end
+
+StubBetterBagsModule("Items")
+local movementFlow = StubBetterBagsModule("MovementFlow")
+movementFlow.GetMovementFlow = function() return 0 end
+
+local groups = StubBetterBagsModule("Groups")
+groups.GetGroupForCategory = function() return nil end
+groups.IsDefaultGroup = function() return false end
+
+local L = StubBetterBagsModule("Localization")
+L.G = function(self, key) return key end
+
+-- Mock Grid module
+local mockGridProto = {
+  HideScrollBar = function() end,
+  EnableMouseWheelScroll = function() end,
+  Wipe = function(self)
+    self.cells = {}
+    self.idToCell = {}
+  end,
+  AddCell = function(self, id, cell)
+    table.insert(self.cells, cell)
+    self.idToCell[id] = cell
+  end,
+  RemoveCell = function(self, id)
+    local cell = self.idToCell[id]
+    if cell then
+      for i, c in ipairs(self.cells) do
+        if c == cell then
+          table.remove(self.cells, i)
+          break
+        end
+      end
+      self.idToCell[id] = nil
+    end
+  end,
+  GetCell = function(self, id)
+    return self.idToCell[id]
+  end,
+  Sort = function() end,
+  SortHorizontal = function() end,
+  Draw = function()
+    return 100, 50
+  end,
+  GetContainer = function(self)
+    if not self._container then
+      self._container = CreateFrame("Frame")
+    end
+    return self._container
+  end,
+  Show = function() end,
+  Hide = function() end,
+}
+
+local grid = StubBetterBagsModule("Grid")
+grid.Create = function()
+  local g = setmetatable({
+    cells = {},
+    idToCell = {}
+  }, { __index = mockGridProto })
+  return g
+end
+
+local context = addon:GetModule("Context")
+
+-- Load the SectionFrame module
+LoadBetterBagsModule("frames/section.lua")
+local sectionFrame = addon:GetModule("SectionFrame")
+
+describe("Section Frame", function()
+  before_each(function()
+    sectionFrame:OnInitialize()
+  end)
+
+  after_each(function()
+    ResetModuleStub("Categories", "data/categories.lua")
+    ResetModuleStub("Constants", "core/constants.lua")
+    ResetModuleStub("Sort", "util/sort.lua")
+    ResetModuleStub("Database", "core/database.lua")
+    ResetModuleStub("Themes", "themes/themes.lua")
+    ResetModuleStub("Items", "data/items.lua")
+    ResetModuleStub("MovementFlow", "util/movementflow.lua")
+    ResetModuleStub("Groups", "data/groups.lua")
+    ResetModuleStub("Localization", "core/localization.lua")
+    ResetModuleStub("Grid", "frames/grid.lua")
+  end)
+
+  describe("Creation and Pooling", function()
+    it("creates a new section frame", function()
+      local ctx = context:New("TestCreate")
+      local s = sectionFrame:Create(ctx)
+      assert.is_not_nil(s)
+      assert.is_not_nil(s.frame)
+      assert.is_not_nil(s.title)
+      assert.is_not_nil(s.content)
+      assert.are.equal(s.title:GetText(), "Not set")
+    end)
+
+    it("resets and pools section correctly", function()
+      local ctx = context:New("TestPool")
+      local s = sectionFrame:Create(ctx)
+      s:SetTitle("Category A")
+      s:SetCollapsed(true)
+      s:Release(ctx)
+      -- Acquire again, should be reset (collapsed=false, but text remains until overwritten)
+      local s2 = sectionFrame:Create(ctx)
+      assert.are.equal(s2.title:GetText(), "Category A")
+      assert.is_false(s2:IsCollapsed())
+    end)
+  end)
+
+  describe("Title and Colors", function()
+    it("sets title correctly", function()
+      local ctx = context:New("TestTitle")
+      local s = sectionFrame:Create(ctx)
+      s:SetTitle("Weapons")
+      assert.are.equal(s:GetTitleWithoutIndicator(), "Weapons")
+    end)
+
+    it("supports custom title color", function()
+      local ctx = context:New("TestColor")
+      local s = sectionFrame:Create(ctx)
+      s:SetTitle("Epic Items", {1, 0, 0}) -- Red color
+      local r, g, b, a = s.title:GetFontString():GetTextColor()
+      assert.are.equal(r, 1)
+      assert.are.equal(g, 0)
+      assert.are.equal(b, 0)
+      assert.are.equal(a, 1)
+    end)
+  end)
+
+  describe("Collapsed State", function()
+    it("sets and retrieves collapsed state", function()
+      local ctx = context:New("TestCollapse")
+      local s = sectionFrame:Create(ctx)
+      assert.is_false(s:IsCollapsed())
+      s:SetCollapsed(true)
+      assert.is_true(s:IsCollapsed())
+    end)
+  end)
+
+  describe("Cells Management", function()
+    it("manages cells correctly", function()
+      local ctx = context:New("TestCells")
+      local s = sectionFrame:Create(ctx)
+      local mockCell = { Release = function() end }
+      s:AddCell("cell1", mockCell)
+      assert.are.equal(s:GetCellCount(), 1)
+      assert.is_true(s:HasItem(mockCell))
+      s:RemoveCell("cell1")
+      assert.are.equal(s:GetCellCount(), 0)
+    end)
+  end)
+
+  describe("Draw and Sizing", function()
+    it("returns correct width and height when drawing standard section", function()
+      local ctx = context:New("TestDraw")
+      local s = sectionFrame:Create(ctx)
+      s:AddCell("cell1", {})
+      local w, h = s:Draw(const.BAG_KIND.BACKPACK, nil, false)
+      assert.are.equal(w, 112)
+      assert.are.equal(h, 74)
+    end)
+  end)
+end)

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -3,22 +3,258 @@
 
 -- Core game functions
 _G.GetTime = function() return os.clock() end
-_G.CreateFrame = function(_, name, _, _)
-  local frame = {
-    SetScript = function() end,
-    Show = function() end,
-    Hide = function() end,
-    RegisterEvent = function() end,
-    UnregisterEvent = function() end,
-    SetOwner = function() end,
-  }
+
+-- Stateful Widget factory helper
+local function CreateMockWidget(widgetType, name, parent)
+  local widget = {}
+  widget._type = widgetType
+  widget._name = name
+  widget._parent = parent
+  widget._shown = true
+  widget._width = 0
+  widget._height = 0
+  widget._alpha = 1
+  widget._text = ""
+  widget._scripts = {}
+  widget._events = {}
+  widget._children = {}
+  widget._points = {}
+  widget._textures = {}
+  widget._fontstrings = {}
+
+  -- Core frame behavior
+  function widget:SetScript(scriptName, handler)
+    self._scripts[scriptName] = handler
+  end
+  function widget:GetScript(scriptName)
+    return self._scripts[scriptName]
+  end
+  function widget:Show()
+    self._shown = true
+  end
+  function widget:Hide()
+    self._shown = false
+  end
+  function widget:IsShown()
+    return self._shown
+  end
+  function widget:RegisterEvent(event)
+    self._events[event] = true
+  end
+  function widget:UnregisterEvent(event)
+    self._events[event] = nil
+  end
+  function widget:SetOwner(owner, anchor, x, y)
+    self._owner = owner
+    self._anchor = anchor
+    self._ownerX = x
+    self._ownerY = y
+  end
+  function widget:SetParent(parentFrame)
+    self._parent = parentFrame
+  end
+  function widget:GetParent()
+    return self._parent
+  end
+  function widget:SetSize(w, h)
+    self._width = w
+    self._height = h
+  end
+  function widget:SetWidth(w)
+    self._width = w
+  end
+  function widget:SetHeight(h)
+    self._height = h
+  end
+  function widget:GetWidth()
+    return self._width or 0
+  end
+  function widget:GetHeight()
+    return self._height or 0
+  end
+  function widget:SetAlpha(alpha)
+    self._alpha = alpha
+  end
+  function widget:GetAlpha()
+    return self._alpha or 1
+  end
+  function widget:SetAllPoints(other)
+    self._allPoints = other or true
+  end
+  function widget:ClearAllPoints()
+    self._points = {}
+  end
+  function widget:SetPoint(point, relativeTo, relativePoint, x, y)
+    table.insert(self._points, {
+      point = point,
+      relativeTo = relativeTo,
+      relativePoint = relativePoint,
+      x = x,
+      y = y
+    })
+  end
+  function widget:EnableMouse(enable)
+    self._mouseEnabled = enable
+  end
+  function widget:RegisterForClicks(...)
+    self._registeredClicks = {...}
+  end
+  function widget:RegisterForDrag(...)
+    self._registeredDrags = {...}
+  end
+
+  -- Textures and FontStrings
+  function widget:CreateTexture(textureName, drawLayer, inherits)
+    local tex = CreateMockWidget("Texture", textureName, self)
+    tex._drawLayer = drawLayer
+    tex._inherits = inherits
+    table.insert(self._textures, tex)
+    return tex
+  end
+  function widget:CreateFontString(fontStringName, drawLayer, inherits)
+    local fs = CreateMockWidget("FontString", fontStringName, self)
+    fs._drawLayer = drawLayer
+    fs._inherits = inherits
+    table.insert(self._fontstrings, fs)
+    return fs
+  end
+  function widget:SetNormalTexture(texture)
+    self._normalTexture = texture
+  end
+  function widget:GetNormalTexture()
+    if not self._normalTexture then
+      self._normalTexture = CreateMockWidget("Texture", nil, self)
+    end
+    return self._normalTexture
+  end
+  function widget:SetHighlightTexture(texture)
+    self._highlightTexture = texture
+  end
+  function widget:SetBlendMode(mode)
+    self._blendMode = mode
+  end
+  function widget:SetTexture(path)
+    self._texturePath = path
+  end
+  function widget:SetNormalAtlas(atlas)
+    self._normalAtlas = atlas
+  end
+  function widget:SetNormalFontObject(fontObject)
+    self._normalFontObject = fontObject
+  end
+  function widget:SetFontString(fontString)
+    self._fontString = fontString
+  end
+  function widget:GetFontString()
+    if not self._fontString then
+      self._fontString = CreateMockWidget("FontString", nil, self)
+    end
+    return self._fontString
+  end
+
+  -- Text and Fonts
+  function widget:SetText(text)
+    self._text = tostring(text or "")
+  end
+  function widget:GetText()
+    return self._text
+  end
+  function widget:GetTextWidth()
+    return #self._text * 6
+  end
+  function widget:GetStringWidth()
+    return #self._text * 6
+  end
+  function widget:SetFont(font, size, flags)
+    self._font = font
+    self._fontSize = size
+    self._fontFlags = flags
+  end
+  function widget:SetTextColor(r, g, b, a)
+    self._textColor = {r = r, g = g, b = b, a = a or 1}
+  end
+  function widget:GetTextColor()
+    if self._textColor then
+      return self._textColor.r, self._textColor.g, self._textColor.b, self._textColor.a
+    end
+    return 1, 1, 1, 1
+  end
+  function widget:GetFontObject()
+    local fo = {
+      GetTextColor = function()
+        return 1, 1, 1, 1
+      end
+    }
+    return fo
+  end
+  function widget:SetVertexColor(r, g, b, a)
+    self._vertexColor = {r = r, g = g, b = b, a = a or 1}
+  end
+  function widget:SetJustifyH(justify)
+    self._justifyH = justify
+  end
+  function widget:GetJustifyH()
+    return self._justifyH
+  end
+  function widget:SetJustifyV(justify)
+    self._justifyV = justify
+  end
+  function widget:GetJustifyV()
+    return self._justifyV
+  end
+
+  -- Strata / Level / Backdrop
+  function widget:SetFrameStrata(strata)
+    self._frameStrata = strata
+  end
+  function widget:SetFrameLevel(level)
+    self._frameLevel = level
+  end
+  function widget:SetBackdrop(backdrop)
+    self._backdrop = backdrop
+  end
+  function widget:SetBackdropColor(r, g, b, a)
+    self._backdropColor = {r = r, g = g, b = b, a = a or 1}
+  end
+  function widget:SetBackdropBorderColor(r, g, b, a)
+    self._backdropBorderColor = {r = r, g = g, b = b, a = a or 1}
+  end
+
+  -- Grid Frame scroll/mousewheel APIs
+  function widget:HideScrollBar()
+    self._scrollBarShown = false
+  end
+  function widget:ShowScrollBar()
+    self._scrollBarShown = true
+  end
+  function widget:EnableMouseWheelScroll(enable)
+    self._mouseWheelScrollEnabled = enable
+  end
+  function widget:GetContainer()
+    if not self._container then
+      self._container = CreateMockWidget("Frame", nil, self)
+    end
+    return self._container
+  end
+
+  return widget
+end
+
+_G.CreateFrame = function(frameType, name, parent, template)
+  local frame = CreateMockWidget(frameType, name, parent)
   if name then
     _G[name] = frame
   end
   return frame
 end
+
 _G.hooksecurefunc = function() end
-_G.UIParent = {}
+_G.UIParent = CreateMockWidget("Frame", "UIParent")
+_G.UIParent:SetSize(1920, 1200)
+function _G.UIParent:GetEffectiveScale()
+  return 1.0
+end
+
 _G.C_Timer = {
   After = function(_, _) end,
   NewTimer = function(_, _)
@@ -91,12 +327,12 @@ _G.time = _G.time or os.time
 
 -- string.split (WoW alias for strsplit, available as string method)
 string.split = string.split or function(sep, str)
-  return strsplit(sep, str)
+  return _G.strsplit(sep, str)
 end
 
 -- strsplittable: like strsplit but returns a table
 _G.strsplittable = function(sep, str, max)
-  return {strsplit(sep, str, max)}
+  return {_G.strsplit(sep, str, max)}
 end
 
 -- Lua 5.1/5.3 compatibility shims
@@ -161,3 +397,228 @@ end
 _G.EquipmentManager_GetLocationData = function()
   return { isBank = false, isBags = true, slot = 1, bag = 0 }
 end
+
+-- Subsystems and Money APIs
+_G._playerMoney = 100000 -- Default to 10 gold (in copper)
+_G._depositedMoney = 50000 -- Default to 5 gold (in copper)
+
+_G.GetMoney = function()
+  return _G._playerMoney
+end
+
+_G.BreakUpLargeNumbers = function(val)
+  local left, right = string.match(tostring(val), "^([^%d]*%d+)(.-)$")
+  if not left then return tostring(val) end
+  return left:reverse():gsub("(%d%d%d)", "%1,"):reverse():gsub("^,", "") .. (right or "")
+end
+
+_G._lastPopupShown = nil
+_G.StaticPopup_Show = function(name, ...)
+  _G._lastPopupShown = { name = name, args = {...} }
+  return {}
+end
+
+_G.PlaySound = function() end
+_G.SOUNDKIT = {
+  IG_BACKPACK_OPEN = 1,
+  IG_BACKPACK_CLOSE = 2,
+}
+
+-- GameTooltip Mock
+_G.GameTooltip = CreateMockWidget("Frame", "GameTooltip")
+_G.GameTooltip.lines = {}
+_G.GameTooltip.doubleLines = {}
+function _G.GameTooltip:SetOwner(owner, anchor, x, y)
+  self._owner = owner
+  self._anchor = anchor
+  self._ownerX = x
+  self._ownerY = y
+  self.lines = {}
+  self.doubleLines = {}
+end
+function _G.GameTooltip:AddLine(text, r, g, b)
+  table.insert(self.lines, {text = text, r = r, g = g, b = b})
+end
+function _G.GameTooltip:AddDoubleLine(left, right, lr, lg, lb, rr, rg, rb)
+  table.insert(self.doubleLines, {left = left, right = right, lr = lr, lg = lg, lb = lb, rr = rr, rg = rg, rb = rb})
+end
+
+-- Cursor APIs
+_G._cursorHasItem = false
+_G._isShiftKeyDown = false
+_G._isControlKeyDown = false
+_G._isAltKeyDown = false
+_G._cursorType = nil
+_G._cursorItemID = nil
+_G._cursorItemLink = nil
+_G._cursorX = 0
+_G._cursorY = 0
+
+_G.CursorHasItem = function() return _G._cursorHasItem or false end
+_G.IsShiftKeyDown = function() return _G._isShiftKeyDown or false end
+_G.IsControlKeyDown = function() return _G._isControlKeyDown or false end
+_G.IsAltKeyDown = function() return _G._isAltKeyDown or false end
+_G.GetCursorInfo = function() return _G._cursorType, _G._cursorItemID, _G._cursorItemLink end
+_G.ClearCursor = function()
+  _G._cursorHasItem = false
+  _G._cursorType = nil
+  _G._cursorItemID = nil
+  _G._cursorItemLink = nil
+end
+_G.GetCursorPosition = function() return _G._cursorX or 0, _G._cursorY or 0 end
+
+-- Enum Setup
+_G.Enum = _G.Enum or {}
+_G.Enum.BankType = {
+  Account = 1,
+  Character = 2,
+}
+_G.Enum.BagIndex = {
+  Keyring = -2,
+}
+
+-- C_Bank Setup
+_G.C_Bank = _G.C_Bank or {}
+_G.C_Bank.FetchDepositedMoney = function(bankType)
+  return _G._depositedMoney
+end
+
+-- C_Container Setup
+_G.C_Container = _G.C_Container or {}
+_G.C_Container._usedItems = {}
+_G.C_Container.GetBagName = function(bagid)
+  if bagid == -2 then return "Keyring" end
+  return "Mock Bag " .. bagid
+end
+_G.C_Container.GetContainerNumSlots = function(bagid)
+  return 16
+end
+_G.C_Container.GetContainerItemID = function(bagid, slotid)
+  return _G._containerItems and _G._containerItems[bagid] and _G._containerItems[bagid][slotid] or nil
+end
+_G.C_Container.GetContainerItemLink = function(bagid, slotid)
+  local itemID = _G.C_Container.GetContainerItemID(bagid, slotid)
+  if itemID then
+    return string.format("|cffff8000|Hitem:%d:0:0:0:0:0:0:0|h[Mock Item %d]|h|r", itemID, itemID)
+  end
+  return nil
+end
+_G.C_Container.GetContainerNumFreeSlots = function(bagid)
+  return 4, nil
+end
+_G.C_Container.UseContainerItem = function(bagid, slotid, target, bankType, isReagent)
+  table.insert(_G.C_Container._usedItems, {
+    bagid = bagid,
+    slotid = slotid,
+    target = target,
+    bankType = bankType,
+    isReagent = isReagent
+  })
+end
+
+-- ItemLocation Setup
+_G.ItemLocation = _G.ItemLocation or {}
+_G.ItemLocation.CreateFromBagAndSlot = function(_, bagID, slotID)
+  local loc = {
+    _bagID = bagID,
+    _slotID = slotID,
+    _isBagAndSlot = true,
+    _isEquipmentSlot = false,
+  }
+  function loc:GetBagAndSlot() return self._bagID, self._slotID end
+  function loc:GetEquipmentSlot() return nil end
+  function loc:IsEquipmentSlot() return false end
+  function loc:IsBagAndSlot() return true end
+  function loc:IsValid() return true end
+  return loc
+end
+_G.ItemLocation.CreateFromEquipmentSlot = function(_, slotID)
+  local loc = {
+    _bagID = nil,
+    _slotID = nil,
+    _isBagAndSlot = false,
+    _isEquipmentSlot = true,
+    _equipSlot = slotID,
+  }
+  function loc:GetBagAndSlot() return nil, nil end
+  function loc:GetEquipmentSlot() return self._equipSlot end
+  function loc:IsEquipmentSlot() return true end
+  function loc:IsBagAndSlot() return false end
+  function loc:IsValid() return true end
+  return loc
+end
+
+-- Item Setup
+_G.Item = _G.Item or {}
+_G.Item.CreateFromBagAndSlot = function(_, bagID, slotID)
+  local loc = _G.ItemLocation:CreateFromBagAndSlot(bagID, slotID)
+  local item = {
+    _location = loc,
+    _bagID = bagID,
+    _slotID = slotID,
+  }
+  function item:GetItemLocation() return self._location end
+  function item:GetInventoryType() return 1 end
+  function item:IsItemDataLoaded() return true end
+  function item:ContinueOnItemLoad(callback) callback() end
+  function item:IsItemLocked() return false end
+  function item:GetItemName() return "Mock Item" end
+  function item:GetItemIcon() return 12345 end
+  function item:GetItemLink() return "[Mock Item]" end
+  function item:IsItemEmpty() return false end
+  return item
+end
+_G.Item.CreateFromEquipmentSlot = function(_, slotID)
+  local loc = _G.ItemLocation:CreateFromEquipmentSlot(slotID)
+  local item = {
+    _location = loc,
+    _equipSlot = slotID,
+  }
+  function item:GetItemLocation() return self._location end
+  function item:GetInventoryType() return 1 end
+  function item:IsItemDataLoaded() return true end
+  function item:ContinueOnItemLoad(callback) callback() end
+  function item:IsItemLocked() return false end
+  function item:GetItemName() return "Mock Item" end
+  function item:GetItemIcon() return 12345 end
+  function item:GetItemLink() return "[Mock Item]" end
+  function item:IsItemEmpty() return false end
+  return item
+end
+_G.Item.CreateFromItemLocation = function(_, itemLocation)
+  local item = {
+    _location = itemLocation,
+  }
+  function item:GetItemLocation() return self._location end
+  function item:GetInventoryType() return 1 end
+  function item:IsItemDataLoaded() return true end
+  function item:ContinueOnItemLoad(callback) callback() end
+  function item:IsItemLocked() return false end
+  function item:GetItemName() return "Mock Item" end
+  function item:GetItemIcon() return 12345 end
+  function item:GetItemLink() return "[Mock Item]" end
+  function item:IsItemEmpty() return false end
+  return item
+end
+
+-- ContinuableContainer Setup
+_G.ContinuableContainer = _G.ContinuableContainer or {}
+_G.ContinuableContainer.Create = function(_)
+  local container = {
+    _items = {}
+  }
+  function container:AddContinuable(itemMixin)
+    table.insert(self._items, itemMixin)
+  end
+  function container:ContinueOnLoad(callback)
+    callback()
+  end
+  return container
+end
+
+-- Math aliases
+_G.floor = math.floor
+_G.ceil = math.ceil
+_G.abs = math.abs
+_G.max = math.max
+_G.min = math.min

--- a/spec/items_spec.lua
+++ b/spec/items_spec.lua
@@ -9,14 +9,6 @@ LoadBetterBagsModule("core/events.lua")
 local events = addon:GetModule("Events")
 events:OnInitialize()
 
-LoadBetterBagsModule("util/query.lua")
-LoadBetterBagsModule("util/trees/trees.lua")
-LoadBetterBagsModule("util/trees/intervaltree.lua")
-LoadBetterBagsModule("data/search.lua")
-LoadBetterBagsModule("core/async.lua")
-LoadBetterBagsModule("data/stacks.lua")
-LoadBetterBagsModule("data/binding.lua")
-
 -- Stubs for modules items.lua depends on
 local debug = StubBetterBagsModule("Debug")
 debug.Log = function() end
@@ -30,12 +22,24 @@ function L:G(key) return key end
 local equipmentSets = StubBetterBagsModule("EquipmentSets")
 equipmentSets.GetItemSets = function() return nil end
 
+LoadBetterBagsModule("util/query.lua")
+LoadBetterBagsModule("util/trees/trees.lua")
+LoadBetterBagsModule("util/trees/intervaltree.lua")
+LoadBetterBagsModule("data/search.lua")
+LoadBetterBagsModule("core/async.lua")
+LoadBetterBagsModule("data/stacks.lua")
+LoadBetterBagsModule("data/binding.lua")
+
 -- Categories stub (items.lua calls GetModule('Categories'))
 -- Already created by categories_spec if it ran first, otherwise stub it
 local ok = pcall(function() return addon:GetModule("Categories") end)
+local categories
 if not ok then
-  StubBetterBagsModule("Categories")
+  categories = StubBetterBagsModule("Categories")
+else
+  categories = addon:GetModule("Categories")
 end
+categories.GetSortedSearchCategories = categories.GetSortedSearchCategories or function() return {} end
 
 -- Set up constants
 const.BAG_KIND = { UNDEFINED = -1, BACKPACK = 0, BANK = 1 }
@@ -47,6 +51,18 @@ const.ITEM_QUALITY = { Poor = 0, Common = 1, Uncommon = 2, Rare = 3, Epic = 4, L
 const.SEARCH_CATEGORY_GROUP_BY = { NONE = 0, TYPE = 1, SUBTYPE = 2, EXPANSION = 3 }
 const.EXPANSION_MAP = { [0] = "Classic", [1] = "Burning Crusade", [2] = "Wrath", [9] = "The War Within" }
 const.TRADESKILL_MAP = { [0] = "Tailoring", [1] = "Leatherworking", [2] = "Blacksmithing" }
+const.BINDING_MAP = {
+  [0] = "",
+  [1] = "boe",
+  [2] = "soulbound",
+}
+const.BRIEF_EXPANSION_MAP = {
+  [0] = "classic",
+  [1] = "bc",
+  [2] = "wotlk",
+  [3] = "cata",
+  [9] = "tww",
+}
 
 _G.Enum = _G.Enum or {}
 _G.Enum.ItemClass = _G.Enum.ItemClass or { Tradegoods = 7, Container = 1 }
@@ -58,6 +74,7 @@ database.GetStackingOptions = function()
 end
 database.GetCategoryFilter = function() return false end
 database.GetEnableBankBag = function() return false end
+database.GetMarkRecentItems = function() return false end
 
 -- Addon state
 addon.isRetail = true
@@ -730,6 +747,65 @@ describe("Items", function()
       assert.are.equal(1, #movePairs)
       -- Partial move: root has 18, max 20, so only 2 can move
       assert.are.equal(2, movePairs[1].partial)
+    end)
+  end)
+
+  -- ─── LoadItems ──────────────────────────────────────────────────────────────
+
+  describe("LoadItems", function()
+    local savedContainerIDToInventoryID
+    local savedGetItemSubClassInfo
+    local savedGetInventoryItemLink
+
+    before_each(function()
+      savedContainerIDToInventoryID = _G.C_Container.ContainerIDToInventoryID
+      savedGetItemSubClassInfo = _G.C_Item.GetItemSubClassInfo
+      savedGetInventoryItemLink = _G.GetInventoryItemLink
+
+      _G.C_Container.ContainerIDToInventoryID = function() return nil end
+      _G.C_Item.GetItemSubClassInfo = function() return "MockSubClass" end
+      _G.GetInventoryItemLink = function() return nil end
+    end)
+
+    after_each(function()
+      _G.C_Container.ContainerIDToInventoryID = savedContainerIDToInventoryID
+      _G.C_Item.GetItemSubClassInfo = savedGetItemSubClassInfo
+      _G.GetInventoryItemLink = savedGetInventoryItemLink
+    end)
+
+    it("correctly updates search index on item count change without leaking", function()
+      local ctx = addon:GetModule("Context"):New("LoadItemsTest")
+      local kind = const.BAG_KIND.BACKPACK
+
+      -- 1. Load an item with count = 1
+      local item1 = MockData.ItemData({
+        bagid = 1,
+        slotid = 1,
+        slotkey = "1_1",
+        count = 1,
+        name = "Iron Ore"
+      })
+      local dataCache1 = { ["1_1"] = item1 }
+      items:LoadItems(ctx, kind, dataCache1, nil, function() end)
+
+      -- Verify it was added to the search index with count = 1
+      assert.is_true(search:isInIndex("stackcount", 1)["1_1"])
+
+      -- 2. Load the same item slot with count = 5
+      local item2 = MockData.ItemData({
+        bagid = 1,
+        slotid = 1,
+        slotkey = "1_1",
+        count = 5,
+        name = "Iron Ore"
+      })
+      local dataCache2 = { ["1_1"] = item2 }
+      items:LoadItems(ctx, kind, dataCache2, nil, function() end)
+
+      -- Verify that the old stackcount attribute (1) was removed (no leak)
+      assert.is_nil(search:isInIndex("stackcount", 1)["1_1"])
+      -- Verify that the new stackcount attribute (5) was added
+      assert.is_true(search:isInIndex("stackcount", 5)["1_1"])
     end)
   end)
 

--- a/spec/refresh_spec.lua
+++ b/spec/refresh_spec.lua
@@ -335,12 +335,26 @@ describe("Refresh", function()
 
   describe("ExecutePendingUpdates", function()
 
-    it("clears pending flags on combat with pendingWipe", function()
+    it("retains pending flags during combat lockdown and executes them after combat ends", function()
       _G.InCombatLockdown = function() return true end
       refresh.pendingWipe = true
       refresh.pendingBackpack = true
       refresh.pendingBank = true
       refresh:ExecutePendingUpdates()
+      -- Assert that flags are retained during combat lockdown
+      assert.is_true(refresh.pendingWipe)
+      assert.is_true(refresh.pendingBackpack)
+      assert.is_true(refresh.pendingBank)
+
+      -- Simulating leaving combat
+      _G.InCombatLockdown = function() return false end
+      refresh:OnEnable()
+      local eventMap = events._eventMap
+      if eventMap["PLAYER_REGEN_ENABLED"] then
+        eventMap["PLAYER_REGEN_ENABLED"].fn("PLAYER_REGEN_ENABLED", "PLAYER_REGEN_ENABLED")
+      end
+
+      -- After execute, pending flags should be reset.
       assert.is_false(refresh.pendingWipe)
       assert.is_false(refresh.pendingBackpack)
       assert.is_false(refresh.pendingBank)

--- a/spec/stacks_spec.lua
+++ b/spec/stacks_spec.lua
@@ -125,6 +125,23 @@ describe("Stacks", function()
       assert.is_nil(stack:GetStackInfo("h1"))
     end)
 
+    it("does not perform redundant lookup when the last item in a stack is removed", function()
+      local item = MockItemData({slotkey = "s1", itemHash = "h1", count = 1})
+      stack:AddToStack(item)
+
+      local lookupCount = 0
+      local originalGetItemData = items.GetItemDataFromSlotKey
+      items.GetItemDataFromSlotKey = function(self, slotkey)
+        lookupCount = lookupCount + 1
+        return originalGetItemData(self, slotkey)
+      end
+
+      stack:RemoveFromStack(item)
+
+      assert.are.equal(0, lookupCount, "GetItemDataFromSlotKey should not be called when removing the last item")
+      items.GetItemDataFromSlotKey = originalGetItemData
+    end)
+
     it("does nothing for a non-existent item hash", function()
       local item = MockItemData({slotkey = "s1", itemHash = "missing"})
       stack:RemoveFromStack(item) -- should not error

--- a/spec/views/bagview_spec.lua
+++ b/spec/views/bagview_spec.lua
@@ -1,0 +1,182 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Load required modules
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("core/pool.lua")
+
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+-- Stub modules before loading views
+local L = StubBetterBagsModule("Localization")
+L.G = function(self, key) return key end
+
+StubBetterBagsModule("Items")
+
+local themes = StubBetterBagsModule("Themes")
+themes.GetTabButton = function() return {} end
+
+local database = StubBetterBagsModule("Database")
+database.GetBagSizeInfo = function()
+  return { itemsPerRow = 5, columnCount = 4 }
+end
+database.GetBagView = function() return 1 end
+database.GetInBagSearch = function() return false end
+
+local const = StubBetterBagsModule("Constants")
+const.BAG_VIEW = { SECTION_GRID = 1, SECTION_ALL_BAGS = 2 }
+const.BAG_KIND = { BACKPACK = 0, BANK = 1 }
+const.GRID_COMPACT_STYLE = { NONE = 0 }
+const.OFFSETS = {
+  BAG_LEFT_INSET = 10,
+  BAG_TOP_INSET = -40,
+  BAG_RIGHT_INSET = -10,
+  BAG_BOTTOM_INSET = 10,
+  BOTTOM_BAR_HEIGHT = 20,
+  BOTTOM_BAR_BOTTOM_INSET = 5,
+  SCROLLBAR_WIDTH = 12,
+}
+const.BACKPACK_BAGS = { [0] = true, [1] = true }
+
+local sort = StubBetterBagsModule("Sort")
+sort.SortSectionsAlphabetically = function() return true end
+
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+debug.StartProfile = function() end
+debug.EndProfile = function() end
+
+StubBetterBagsModule("Categories")
+StubBetterBagsModule("Groups")
+
+-- Stub SectionFrame
+local sectionFrame = StubBetterBagsModule("SectionFrame")
+local sectionProto = {
+  ReleaseAllCells = function() end,
+  Release = function() end,
+  GetCellCount = function() return 1 end,
+  SetMaxCellWidth = function() end,
+  Draw = function() end,
+}
+sectionFrame.Create = function()
+  return setmetatable({}, { __index = sectionProto })
+end
+
+-- Stub ItemFrame
+local itemFrame = StubBetterBagsModule("ItemFrame")
+itemFrame.Create = function()
+  return {
+    SetItem = function() end,
+    SetFreeSlots = function() end,
+    UpdateCount = function() end,
+  }
+end
+
+-- Mock Grid module
+local mockGridProto = {
+  HideScrollBar = function() end,
+  ShowScrollBar = function() end,
+  EnableMouseWheelScroll = function() end,
+  Wipe = function() end,
+  Sort = function() end,
+  Draw = function() return 100, 50 end,
+  GetContainer = function(self)
+    if not self._container then
+      self._container = CreateFrame("Frame")
+    end
+    return self._container
+  end,
+  Show = function() end,
+  Hide = function() end,
+}
+
+local grid = StubBetterBagsModule("Grid")
+grid.Create = function()
+  return setmetatable({}, { __index = mockGridProto })
+end
+
+-- Load views/views.lua first (provides views:NewBlankView)
+LoadBetterBagsModule("views/views.lua")
+local views = addon:GetModule("Views")
+
+-- Load views/bagview.lua
+LoadBetterBagsModule("views/bagview.lua")
+
+local context = addon:GetModule("Context")
+
+describe("Bag View", function()
+  after_each(function()
+    ResetModuleStub("Localization", "core/localization.lua")
+    ResetModuleStub("Items", "data/items.lua")
+    ResetModuleStub("Themes", "themes/themes.lua")
+    ResetModuleStub("Database", "core/database.lua")
+    ResetModuleStub("Constants", "core/constants.lua")
+    ResetModuleStub("Sort", "util/sort.lua")
+    ResetModuleStub("Debug", "debug/debug.lua")
+    ResetModuleStub("Categories", "data/categories.lua")
+    ResetModuleStub("Groups", "data/groups.lua")
+    ResetModuleStub("SectionFrame", "frames/section.lua")
+    ResetModuleStub("ItemFrame", "frames/item.lua")
+    ResetModuleStub("Grid", "frames/grid.lua")
+    ResetModuleStub("Views", "views/views.lua")
+  end)
+
+  describe("NewBagView", function()
+    it("creates a new bag view correctly", function()
+      local parent = CreateFrame("Frame")
+      local view = views:NewBagView(parent, const.BAG_KIND.BACKPACK)
+      assert.is_not_nil(view)
+      assert.is_not_nil(view.content)
+      assert.are.equal(view.kind, const.BAG_KIND.BACKPACK)
+      assert.are.equal(view.bagview, const.BAG_VIEW.SECTION_ALL_BAGS)
+      assert.is_not_nil(view.Render)
+      assert.is_not_nil(view.WipeHandler)
+    end)
+  end)
+
+  describe("Wipe", function()
+    it("wipes view and releases sections on wipe context", function()
+      local parent = CreateFrame("Frame")
+      local view = views:NewBagView(parent, const.BAG_KIND.BACKPACK)
+      local mockSection = setmetatable({
+        releasedCells = false,
+        released = false,
+      }, {
+        __index = {
+          ReleaseAllCells = function(self) self.releasedCells = true end,
+          Release = function(self) self.released = true end,
+        }
+      })
+      view.sections["test_section"] = mockSection
+      local ctx = context:New("WipeView")
+      view:Wipe(ctx)
+      assert.is_true(mockSection.releasedCells)
+      assert.is_true(mockSection.released)
+      assert.is_nil(view.sections["test_section"])
+    end)
+  end)
+
+  describe("Render", function()
+    it("renders the bag view and computes sizes correctly", function()
+      local parent = CreateFrame("Frame")
+      local view = views:NewBagView(parent, const.BAG_KIND.BACKPACK)
+      local bag = {
+        kind = const.BAG_KIND.BACKPACK,
+        frame = CreateFrame("Frame"),
+      }
+      local slotInfo = {
+        GetChangeset = function() return {}, {}, {} end,
+        emptySlotByBagAndSlot = {}
+      }
+      local callbackCalled = false
+      local callback = function()
+        callbackCalled = true
+      end
+      local ctx = context:New("RenderView")
+      view:Render(ctx, bag, slotInfo, callback)
+      assert.is_true(callbackCalled)
+      assert.are.equal(bag.frame:GetHeight(), 50 + 10 + 40 + 20 + 5) -- h + bottom offsets
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary
This PR fixes 4 identified bugs in the data stack of BetterBags.

### Motivation
To resolve regressions and maintain expected behavior in the Refresh, Search, Stacks, and Categories subsystems:
1. Retain update flags correctly during combat lockdown (Refresh).
2. Clean up old attributes from the search index when items change (Search).
3. Avoid redundant and expensive lookups on disposed stacks (Stacks).
4. Correctly invalidate the \`nil\` category cache when an item is added or removed from dynamic categories (Categories).

### Testing/Validation
All bugs were addressed using a strict RED/GREEN TDD workflow:
1. **Refresh Subsystem**: Modified \`spec/refresh_spec.lua\` to assert flags are retained in combat and subsequently processed. Fixed in \`data/refresh.lua:ExecutePendingUpdates()\` by returning early if \`InCombatLockdown()\` without clearing flags.
2. **Search Subsystem**: Added test in \`spec/items_spec.lua\` to ensure index cleanup on \`LoadItems\`. Fixed in \`data/items.lua:LoadItems()\` to call \`search:Remove(previousItem)\`.
3. **Stacks Subsystem**: Added spy test in \`spec/stacks_spec.lua\` to assert \`GetItemDataFromSlotKey\` is called exactly 0 times upon stack disposal. Fixed in \`data/stacks.lua:RemoveFromStack()\` by returning early when a stack is wiped.
4. **Categories Subsystem**: Added test in \`spec/categories_spec.lua\` to verify cache clearing. Fixed in \`data/categories.lua\` to set \`self.itemsWithNoCategory[id] = nil\` in addition and removal functions.

- Tests pass locally (\`822 successes / 0 failures / 0 errors\`).
- Linter passes cleanly (\`luacheck .\`).