### PR TITLE
style: change custom category item list font to normal

### DIFF
--- a/frames/era/itemrow.lua
+++ b/frames/era/itemrow.lua
@@ -114,7 +114,7 @@ function item:_DoCreate(ctx)
   text:SetTextHeight(28)
   text:SetWordWrap(true)
   text:SetJustifyH("LEFT")
-  text:SetFont("Fonts\\FRIZQT__.TTF", 14, "THICKOUTLINE")
+  text:SetFont("Fonts\\FRIZQT__.TTF", 14, "")
   text:SetShadowColor(0, 0, 0, 1)
   i.text = text
 

--- a/frames/itemrow.lua
+++ b/frames/itemrow.lua
@@ -225,7 +225,7 @@ function item:_DoCreate(ctx)
   text:SetTextHeight(28)
   text:SetWordWrap(true)
   text:SetJustifyH("LEFT")
-  text:SetFont("Fonts\\FRIZQT__.TTF", 14, "THICKOUTLINE")
+  text:SetFont("Fonts\\FRIZQT__.TTF", 14, "")
   text:SetShadowColor(0, 0, 0, 1)
   i.text = text
 

--- a/spec/itemrow_spec.lua
+++ b/spec/itemrow_spec.lua
@@ -58,19 +58,19 @@ describe("ItemRow Frame Font Validation", function()
     ctx = context:New("ItemRowTest")
   end)
 
-  it("should successfully initialize because of the valid 'THICKOUTLINE' font flag in retail", function()
+  it("should successfully initialize because of the valid normal font flag in retail", function()
     ResetModuleStub("ItemRowFrame", "frames/itemrow.lua")
     LoadBetterBagsModule("frames/itemrow.lua")
     local itemRowFrame = addon:GetModule("ItemRowFrame")
     itemRowFrame:OnInitialize()
 
-    -- This should NOT throw a SetFont error anymore because 'THICKOUTLINE' is valid
+    -- This should NOT throw a SetFont error anymore because '' is valid
     assert.has_no_error(function()
       itemRowFrame:Create(ctx)
     end)
   end)
 
-  it("should successfully initialize because of the valid 'THICKOUTLINE' font flag in era", function()
+  it("should successfully initialize because of the valid normal font flag in era", function()
     -- First make sure the main ItemRowFrame is loaded
     ResetModuleStub("ItemRowFrame", "frames/itemrow.lua")
     LoadBetterBagsModule("frames/itemrow.lua")
@@ -79,7 +79,7 @@ describe("ItemRow Frame Font Validation", function()
     LoadBetterBagsModule("frames/era/itemrow.lua")
     local itemRowFrame = addon:GetModule("ItemRowFrame")
 
-    -- This should NOT throw a SetFont error anymore because 'THICKOUTLINE' is valid
+    -- This should NOT throw a SetFont error anymore because '' is valid
     assert.has_no_error(function()
       itemRowFrame:_DoCreate(ctx)
     end)


### PR DESCRIPTION
### Summary of Changes
This pull request changes the font outline style of the custom category item list rows from `'THICKOUTLINE'` to standard/normal font (by setting the outline flag to `''`). This removes the heavy bold black stroke outline and matches the rest of the options UI.

### Validation
- All unit tests pass (`826 successes / 0 failures / 0 errors / 0 pending`).
- `luacheck` is completely clean (`0 warnings / 0 errors`).