### PR TITLE
Fix bank/bag slots flat window header overlap in Default theme

### DIFF
--- a/frames/bagslots.lua
+++ b/frames/bagslots.lua
@@ -55,7 +55,16 @@ function BagSlots.bagSlotProto:Draw(ctx)
     maxWidthPerRow = 1024,
   })
   self.frame:SetWidth(w + const.OFFSETS.BAG_LEFT_INSET + -const.OFFSETS.BAG_RIGHT_INSET + 4)
-  self.frame:SetHeight(h + 42)
+
+  local headerHeight = themes:GetFlatHeaderHeight(self.frame)
+  local topInset = headerHeight > 0 and headerHeight or 12
+  local leftInset = addon.isRetail and (const.OFFSETS.BAG_LEFT_INSET + 4) or const.OFFSETS.BAG_LEFT_INSET
+
+  self.content:GetContainer():ClearAllPoints()
+  self.content:GetContainer():SetPoint("TOPLEFT", self.frame, "TOPLEFT", leftInset, -topInset)
+  self.content:GetContainer():SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, 12)
+
+  self.frame:SetHeight(h + topInset + 12)
 end
 
 function BagSlots.bagSlotProto:SetShown(shown)

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -149,8 +149,16 @@ function BankSlots.bankSlotsPanelProto:Draw(ctx)
     maxWidthPerRow = 1024,
   })
   self.frame:SetWidth(w + const.OFFSETS.BAG_LEFT_INSET + -const.OFFSETS.BAG_RIGHT_INSET + 4)
-  -- Height = content height + top inset (12) + bottom inset (12).
-  self.frame:SetHeight(h + 24)
+
+  local headerHeight = themes:GetFlatHeaderHeight(self.frame)
+  local topInset = headerHeight > 0 and headerHeight or 12
+
+  self.content:GetContainer():ClearAllPoints()
+  self.content:GetContainer():SetPoint("TOPLEFT", self.frame, "TOPLEFT", const.OFFSETS.BAG_LEFT_INSET + 4, -topInset)
+  self.content:GetContainer():SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, 12)
+
+  -- Height = content height + top inset + bottom inset (12).
+  self.frame:SetHeight(h + topInset + 12)
 
   -- Enforce minimum bag frame width so the main bank window is never
   -- narrower than the bank tab panel anchored below it.

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -41,6 +41,9 @@ local function CreateMockWidget(widgetType, name, parent)
   function widget:SetShown(shown)
     self._shown = shown
   end
+  function widget:GetName()
+    return self._name
+  end
   function widget:RegisterEvent(event)
     self._events[event] = true
   end

--- a/spec/themes_spec.lua
+++ b/spec/themes_spec.lua
@@ -1,0 +1,117 @@
+-- themes_spec.lua -- Unit tests for themes/themes.lua and flat frame layout offsets.
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Stub dependencies
+local const = StubBetterBagsModule("Constants")
+const.WINDOW_KIND = {
+  PORTRAIT = "portrait",
+  SIMPLE = "simple",
+  FLAT = "flat"
+}
+
+local L = StubBetterBagsModule("Localization")
+L.G = function(self, key) return key end
+
+local events = StubBetterBagsModule("Events")
+events.SendMessage = function() end
+
+local async = StubBetterBagsModule("Async")
+async.AfterCombat = function(self, fn) fn() end
+
+local db = StubBetterBagsModule("Database")
+
+-- Load the real Context module
+LoadBetterBagsModule("core/context.lua")
+
+-- Load the real Themes module
+LoadBetterBagsModule("themes/themes.lua")
+local themes = addon:GetModule("Themes")
+
+describe("Themes", function()
+  local activeTheme = "Default"
+
+  before_each(function()
+    activeTheme = "Default"
+    db.GetTheme = function() return activeTheme end
+    db.SetTheme = function(self, key) activeTheme = key end
+    db.GetBagSizeInfo = function() return { opacity = 100 } end
+    db.GetBagView = function() return "section" end
+    db.GetInBagSearch = function() return false end
+
+    themes.themes = {}
+    themes:OnInitialize()
+  end)
+
+  after_each(function()
+    ResetModuleStub("Themes", "themes/themes.lua")
+    ResetModuleStub("Context", "core/context.lua")
+  end)
+
+  describe("GetFlatHeaderHeight", function()
+    it("should return 30 for any frame with a non-empty title", function()
+      local frame = CreateFrame("Frame", "TestFlatFrameWithTitle")
+      themes:RegisterFlatWindow(frame, "Some Title")
+
+      -- Assert height is 30
+      assert.are.equal(30, themes:GetFlatHeaderHeight(frame))
+    end)
+
+    it("should return 30 for flat frame with empty title in Default theme", function()
+      local frame = CreateFrame("Frame", "TestFlatFrameNoTitleDefault")
+      themes:RegisterFlatWindow(frame, "")
+
+      -- Assert height is 30
+      assert.are.equal(30, themes:GetFlatHeaderHeight(frame))
+    end)
+
+    it("should return 0 for flat frame with empty title in SimpleDark theme", function()
+      local frame = CreateFrame("Frame", "TestFlatFrameNoTitleSimpleDark")
+      themes:RegisterFlatWindow(frame, "")
+
+      -- Setup simple dark theme mock
+      themes:RegisterTheme("SimpleDark", {
+        Name = "Simple Dark",
+        Available = true,
+        Portrait = function() end,
+        Simple = function() end,
+        Flat = function() end,
+        Opacity = function() end,
+        SectionFont = function() end,
+        Reset = function() end,
+        SetTitle = function() end,
+        ToggleSearch = function() end,
+      })
+      activeTheme = "SimpleDark"
+
+      -- Assert height is 0
+      assert.are.equal(0, themes:GetFlatHeaderHeight(frame))
+    end)
+
+    it("should return custom value from theme callback if defined", function()
+      local frame = CreateFrame("Frame", "TestFlatFrameNoTitleCustom")
+      themes:RegisterFlatWindow(frame, "")
+
+      -- Setup a theme with custom callback
+      themes:RegisterTheme("CustomTheme", {
+        Name = "Custom Theme",
+        Available = true,
+        Portrait = function() end,
+        Simple = function() end,
+        Flat = function() end,
+        Opacity = function() end,
+        SectionFont = function() end,
+        Reset = function() end,
+        SetTitle = function() end,
+        ToggleSearch = function() end,
+        GetFlatHeaderHeight = function(f)
+          return 45
+        end,
+      })
+      activeTheme = "CustomTheme"
+
+      -- Assert height is 45
+      assert.are.equal(45, themes:GetFlatHeaderHeight(frame))
+    end)
+  end)
+end)

--- a/themes/README.md
+++ b/themes/README.md
@@ -63,6 +63,7 @@ WINDOW_KIND = {
 | `GetAllThemes()` | Get available themes | - | `table<string, Theme>` |
 | `UpdateOpacity()` | Update frame opacity | - | - |
 | `SetTitle(frame, title)` | Set frame title | `Frame`, `string` | - |
+| `GetFlatHeaderHeight(frame)` | Get flat frame header height for layout | `Frame` | `number` |
 
 ### Theme Registration
 
@@ -257,6 +258,8 @@ Every theme must implement the following interface:
 
 **Tab(tab)** - Custom tab styling
 
+**GetFlatHeaderHeight(frame)** - Return custom flat window header height for layout (returns `number`)
+
 ## Creating Custom Themes
 
 ### Basic Theme Template
@@ -406,6 +409,7 @@ end
 | `OffsetSidebar` | function | No | Sidebar offset |
 | `ItemButton` | function | No | Item button styling |
 | `Tab` | function | No | Tab styling |
+| `GetFlatHeaderHeight` | function | No | Flat window header height override |
 | `DisableMasque` | boolean | No | Disable Masque integration |
 
 ### Context Access

--- a/themes/themes.lua
+++ b/themes/themes.lua
@@ -41,6 +41,7 @@ local context = addon:GetModule('Context')
 ---@field OffsetSidebar? fun(): number A function that offsets the sidebar by x pixels.
 ---@field ItemButton? fun(button: Item): ItemButton A function that applies the theme to an item button.
 ---@field Tab? fun(tab: Button): PanelTabButtonTemplate A function that applies the theme to a tab.
+---@field GetFlatHeaderHeight? fun(frame: Frame): number A function that returns the height of the flat header.
 ---@field Reset fun() A function that resets the theme to its default state and removes any special styling.
 ---@field DisableMasque? boolean If set to true, Masque will not be used with this theme.
 
@@ -285,6 +286,33 @@ function themes:SetTitle(frame, title)
   local theme = self.themes[db:GetTheme()]
   theme.SetTitle(frame, title)
   self.titles[frame:GetName()] = title
+end
+
+-- GetFlatHeaderHeight returns the flat frame header height for layout purposes.
+---@param frame Frame
+---@return number
+function themes:GetFlatHeaderHeight(frame)
+  local title = self.titles[frame:GetName()]
+  if title and title ~= "" then
+    return 30
+  end
+
+  local activeThemeKey = db:GetTheme()
+  local activeTheme = self.themes[activeThemeKey]
+
+  -- If the theme implements a custom GetFlatHeaderHeight, call it.
+  if activeTheme and activeTheme.GetFlatHeaderHeight then
+    return activeTheme.GetFlatHeaderHeight(frame)
+  end
+
+  -- For the Default theme, even without a title, the flat frame template
+  -- (DefaultPanelFlatTemplate) renders a 30px visual top header/border area.
+  if activeThemeKey == 'Default' then
+    return 30
+  end
+
+  -- Default to 0 for other borderless/headerless flat windows (Simple Dark, GW2, etc.)
+  return 0
 end
 
 ---@param ctx Context


### PR DESCRIPTION
### Summary
Fixes an issue where the bank/bag slots overlap with the flat window header when the default theme is used.

### Motivation
When we show bank bags in the bank with the bottom bar in the default theme, we did not account for the header. Headerless windows (e.g. gw2, simple dark) worked fine, but the default theme caused overlap.

### Validation
- Added a theme-aware API \`themes:GetFlatHeaderHeight(frame)\`
- Updated \`frames/bankslots.lua\` and \`frames/bagslots.lua\` to use the dynamic inset.
- Added comprehensive unit tests in \`spec/themes_spec.lua\`.
- Ran full test suite (830 passing tests) and \`luacheck .\` (0 warnings).