### PR TITLE
fix(theme): fix retail bank slots positioning under GW2 theme during switch

### DIFF
--- a/spec/themes_spec.lua
+++ b/spec/themes_spec.lua
@@ -317,4 +317,164 @@ describe("Themes", function()
       assert.is_true(slotsDrawCalled)
     end)
   end)
+
+  describe("GW2 theme PositionBagSlots", function()
+    local gw2Theme
+
+    before_each(function()
+      _G.GW2_ADDON = {
+        CreateFrameHeaderWithBody = function() end,
+        SkinBagSearchBox = function() end,
+        BackdropTemplates = { Default = {} },
+      }
+      StubBetterBagsModule("ContextMenu")
+      StubBetterBagsModule("SearchBox")
+      local fonts = StubBetterBagsModule("Fonts")
+      fonts.UnitFrame12White = {}
+
+      -- Load gw2.lua
+      local fn = assert(loadfile("themes/gw2.lua"))
+      fn("BetterBags")
+      gw2Theme = themes.themes["GW2"]
+    end)
+
+    after_each(function()
+      _G.GW2_ADDON = nil
+      ResetModuleStub("ContextMenu")
+      ResetModuleStub("SearchBox")
+      ResetModuleStub("Fonts")
+    end)
+
+    it("should anchor shown retail bank slots to the bottom", function()
+      addon.isRetail = true
+      local frame = CreateFrame("Frame", "TestGW2BankWindow")
+      local slotsFramePoints = {}
+
+      local slotsMock = {
+        frame = CreateFrame("Frame", "TestGW2BankSlotsFrame"),
+        IsShown = function() return true end,
+      }
+
+      slotsMock.frame.ClearAllPoints = function()
+        slotsFramePoints = {}
+      end
+      slotsMock.frame.SetPoint = function(self, point, relFrame, relPoint, x, y)
+        table.insert(slotsFramePoints, { point = point, relFrame = relFrame, relPoint = relPoint, x = x, y = y })
+      end
+
+      frame.Owner = {
+        kind = const.BAG_KIND.BANK,
+        slots = slotsMock,
+      }
+
+      gw2Theme.PositionBagSlots(frame, slotsMock.frame)
+
+      assert.is_true(#slotsFramePoints > 0)
+      local lastPoint = slotsFramePoints[#slotsFramePoints]
+      assert.are.equal("TOPLEFT", lastPoint.point)
+      assert.are.equal(frame, lastPoint.relFrame)
+      assert.are.equal("BOTTOMLEFT", lastPoint.relPoint)
+      assert.are.equal(0, lastPoint.x)
+      assert.are.equal(-2, lastPoint.y)
+    end)
+
+    it("should anchor hidden retail bank slots to the top starting position", function()
+      addon.isRetail = true
+      local frame = CreateFrame("Frame", "TestGW2BankWindowHidden")
+      local slotsFramePoints = {}
+
+      local slotsMock = {
+        frame = CreateFrame("Frame", "TestGW2BankSlotsFrameHidden"),
+        IsShown = function() return false end,
+      }
+
+      slotsMock.frame.ClearAllPoints = function()
+        slotsFramePoints = {}
+      end
+      slotsMock.frame.SetPoint = function(self, point, relFrame, relPoint, x, y)
+        table.insert(slotsFramePoints, { point = point, relFrame = relFrame, relPoint = relPoint, x = x, y = y })
+      end
+
+      frame.Owner = {
+        kind = const.BAG_KIND.BANK,
+        slots = slotsMock,
+      }
+
+      gw2Theme.PositionBagSlots(frame, slotsMock.frame)
+
+      assert.is_true(#slotsFramePoints > 0)
+      local lastPoint = slotsFramePoints[#slotsFramePoints]
+      assert.are.equal("BOTTOMLEFT", lastPoint.point)
+      assert.are.equal(frame, lastPoint.relFrame)
+      assert.are.equal("TOPLEFT", lastPoint.relPoint)
+      assert.are.equal(0, lastPoint.x)
+      assert.are.equal(14, lastPoint.y)
+    end)
+
+    it("should anchor retail backpack slots to the custom top position (8, 16)", function()
+      addon.isRetail = true
+      local frame = CreateFrame("Frame", "TestGW2BackpackWindow")
+      local slotsFramePoints = {}
+
+      local slotsMock = {
+        frame = CreateFrame("Frame", "TestGW2BackpackSlotsFrame"),
+        IsShown = function() return true end,
+      }
+
+      slotsMock.frame.ClearAllPoints = function()
+        slotsFramePoints = {}
+      end
+      slotsMock.frame.SetPoint = function(self, point, relFrame, relPoint, x, y)
+        table.insert(slotsFramePoints, { point = point, relFrame = relFrame, relPoint = relPoint, x = x, y = y })
+      end
+
+      frame.Owner = {
+        kind = const.BAG_KIND.BACKPACK,
+        slots = slotsMock,
+      }
+
+      gw2Theme.PositionBagSlots(frame, slotsMock.frame)
+
+      assert.is_true(#slotsFramePoints > 0)
+      local lastPoint = slotsFramePoints[#slotsFramePoints]
+      assert.are.equal("BOTTOMLEFT", lastPoint.point)
+      assert.are.equal(frame, lastPoint.relFrame)
+      assert.are.equal("TOPLEFT", lastPoint.relPoint)
+      assert.are.equal(8, lastPoint.x)
+      assert.are.equal(16, lastPoint.y)
+    end)
+
+    it("should anchor classic bank slots to the custom top position (8, 16)", function()
+      addon.isRetail = false
+      local frame = CreateFrame("Frame", "TestGW2ClassicBankWindow")
+      local slotsFramePoints = {}
+
+      local slotsMock = {
+        frame = CreateFrame("Frame", "TestGW2ClassicBankSlotsFrame"),
+        IsShown = function() return true end,
+      }
+
+      slotsMock.frame.ClearAllPoints = function()
+        slotsFramePoints = {}
+      end
+      slotsMock.frame.SetPoint = function(self, point, relFrame, relPoint, x, y)
+        table.insert(slotsFramePoints, { point = point, relFrame = relFrame, relPoint = relPoint, x = x, y = y })
+      end
+
+      frame.Owner = {
+        kind = const.BAG_KIND.BANK,
+        slots = slotsMock,
+      }
+
+      gw2Theme.PositionBagSlots(frame, slotsMock.frame)
+
+      assert.is_true(#slotsFramePoints > 0)
+      local lastPoint = slotsFramePoints[#slotsFramePoints]
+      assert.are.equal("BOTTOMLEFT", lastPoint.point)
+      assert.are.equal(frame, lastPoint.relFrame)
+      assert.are.equal("TOPLEFT", lastPoint.relPoint)
+      assert.are.equal(8, lastPoint.x)
+      assert.are.equal(16, lastPoint.y)
+    end)
+  end)
 end)

--- a/themes/gw2.lua
+++ b/themes/gw2.lua
@@ -233,7 +233,15 @@ local gw2Theme = {
   end,
   PositionBagSlots = function (frame, bagSlotWindow)
     bagSlotWindow:ClearAllPoints()
-    bagSlotWindow:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 8, 16)
+    if addon.isRetail and frame.Owner.kind == const.BAG_KIND.BANK then
+      if frame.Owner.slots:IsShown() then
+        bagSlotWindow:SetPoint("TOPLEFT", frame, "BOTTOMLEFT", 0, -2)
+      else
+        bagSlotWindow:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 0, 14)
+      end
+    else
+      bagSlotWindow:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 8, 16)
+    end
   end,
   OffsetSidebar = function()
     return -35


### PR DESCRIPTION
### Summary
This PR fixes an issue where swapping to or from the GW2 theme while the bank window is open caused the bank slots panel (the bottom bar in Retail) to be incorrectly anchored to the top of the bank window.

### Motivation
The GW2 theme implements a custom `PositionBagSlots` function, which unconditionally anchors all slots panels to the top of the window as a slide-out panel. While correct for the backpack, this overrides the default bottom anchoring for the retail bank slots panel, causing visual bugs when themes are switched on the fly. 

### Testing / Validation
- Added comprehensive TDD unit tests in `spec/themes_spec.lua` to validate `gw2Theme.PositionBagSlots` across different states (shown/hidden) and bag kinds (backpack/bank).
- Verified that retail bank slots now dock to the bottom when shown, or sit at the start/slide point when hidden, identical to the default theme.
- Verified that backpack slots and all panels under Classic/Era retain the standard GW2 top-slide-out positioning.
- Confirmed all 838 unit tests pass successfully.
- Verified codebase with `luacheck` showing zero warnings.