### PR TITLE
Fix Bank Bag Slot Pane Bugs, Retail Character Bank Tabs, and Warbank Configuration

### DIFF
--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -209,6 +209,8 @@ function bank.proto:OnHide()
 			-- auto-reappear when the bank is reopened (bag.frame:Show() would
 			-- otherwise re-show any child whose IsShown() is still true).
 			if self.bag.slots then
+				local ctx = context:New("OnHide")
+				self.bag.slots:OnClose(ctx)
 				self.bag.slots.frame:Hide()
 			end
 			ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
@@ -218,6 +220,8 @@ function bank.proto:OnHide()
 		self.bag.frame:Hide()
 		-- Explicitly reset the bank slots panel's shown state (see fade path above).
 		if self.bag.slots then
+			local ctx = context:New("OnHide")
+			self.bag.slots:OnClose(ctx)
 			self.bag.slots.frame:Hide()
 		end
 		ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
@@ -319,6 +323,10 @@ function bank.proto:RegisterEvents()
 	local behavior = self
 
 	events:RegisterEvent("PLAYER_ACCOUNT_BANK_TAB_SLOTS_CHANGED", function(ectx)
+		behavior:GenerateGroupTabs(ectx)
+	end)
+
+	events:RegisterEvent("PLAYER_BANK_TAB_SLOTS_CHANGED", function(ectx)
 		behavior:GenerateGroupTabs(ectx)
 	end)
 

--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -210,7 +210,9 @@ function bank.proto:OnHide()
 			-- otherwise re-show any child whose IsShown() is still true).
 			if self.bag.slots then
 				local ctx = context:New("OnHide")
-				self.bag.slots:OnClose(ctx)
+				if self.bag.slots.OnClose then
+					self.bag.slots:OnClose(ctx)
+				end
 				self.bag.slots.frame:Hide()
 			end
 			ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
@@ -221,7 +223,9 @@ function bank.proto:OnHide()
 		-- Explicitly reset the bank slots panel's shown state (see fade path above).
 		if self.bag.slots then
 			local ctx = context:New("OnHide")
-			self.bag.slots:OnClose(ctx)
+			if self.bag.slots.OnClose then
+				self.bag.slots:OnClose(ctx)
+			end
 			self.bag.slots.frame:Hide()
 		end
 		ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)

--- a/frames/bagslots.lua
+++ b/frames/bagslots.lua
@@ -115,6 +115,15 @@ function BagSlots.bagSlotProto:IsShown()
   return self.frame:IsShown()
 end
 
+---@param _ctx Context
+function BagSlots.bagSlotProto:OnClose(_ctx)
+  local parentBag = addon.Bags and (self.kind == const.BAG_KIND.BACKPACK and addon.Bags.Backpack or addon.Bags.Bank)
+  if self.tabsWereShown and parentBag and parentBag.tabs then
+    parentBag.tabs.frame:Show()
+  end
+  self.tabsWereShown = false
+end
+
 ---@param ctx Context
 ---@param kind BagKind
 ---@param bagFrame Frame

--- a/frames/bagslots.lua
+++ b/frames/bagslots.lua
@@ -80,10 +80,14 @@ function BagSlots.bagSlotProto:Show(callback)
 
   local parentBag = addon.Bags and (self.kind == const.BAG_KIND.BACKPACK and addon.Bags.Backpack or addon.Bags.Bank)
   if parentBag and parentBag.tabs then
-    self.tabsWereShown = parentBag.tabs.frame:IsShown()
+    if not self:IsShown() then
+      self.tabsWereShown = parentBag.tabs.frame:IsShown()
+    end
     parentBag.tabs.frame:Hide()
   else
-    self.tabsWereShown = false
+    if not self:IsShown() then
+      self.tabsWereShown = false
+    end
   end
 
   if callback then
@@ -172,7 +176,7 @@ function BagSlots:CreatePanel(ctx, kind, bagFrame)
 
   events:RegisterEvent('BAG_CONTAINER_UPDATE', function(ectx) b:Draw(ectx) end)
   if not addon.isRetail then
-    events:RegisterEvent('PLAYERBANKBAGSLOTS_CHANGED', function(ectx) b:Draw(ectx) end)
+    events:RegisterEvent('PLAYERBANKSLOTS_CHANGED', function(ectx) b:Draw(ectx) end)
   end
   b.kind = kind
   b.frame:Hide()

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -193,10 +193,14 @@ function BankSlots.bankSlotsPanelProto:Show(callback)
   -- they can be restored correctly when the bank slots panel is closed.
   local bankBag = addon.Bags and addon.Bags.Bank
   if bankBag and bankBag.tabs then
-    self.tabsWereShown = bankBag.tabs.frame:IsShown()
+    if not self:IsShown() then
+      self.tabsWereShown = bankBag.tabs.frame:IsShown()
+    end
     bankBag.tabs.frame:Hide()
   else
-    self.tabsWereShown = false
+    if not self:IsShown() then
+      self.tabsWereShown = false
+    end
   end
   self.fadeInGroup:Play()
 end
@@ -248,6 +252,30 @@ function BankSlots.bankSlotsPanelProto:SelectFirstTab(ctx)
     end
     self:SelectTab(ctx, firstBagIndex)
   end
+end
+
+-- OnClose cleans up the bank slots panel state and restores normal view
+---@param ctx Context
+function BankSlots.bankSlotsPanelProto:OnClose(ctx)
+  -- Deselect all buttons
+  for _, btn in ipairs(self.buttons) do
+    btn:SetSelected(false)
+  end
+  self.selectedBagIndex = nil
+  -- Clear the single-tab filter and refresh the bank cache
+  if addon.Bags and addon.Bags.Bank then
+    addon.Bags.Bank.blizzardBankTab = nil
+    items:ClearBankCache(ctx)
+  end
+  -- Restore panel anchor to above the bag frame (original position).
+  self.frame:ClearAllPoints()
+  self.frame:SetPoint("BOTTOMLEFT", self.bagFrame, "TOPLEFT", 0, 14)
+  -- Restore group tabs visibility to what it was before the panel opened.
+  local bankBag = addon.Bags and addon.Bags.Bank
+  if self.tabsWereShown and bankBag and bankBag.tabs then
+    bankBag.tabs.frame:Show()
+  end
+  self.tabsWereShown = false
 end
 
 -- OpenTabConfig opens the Blizzard tab configuration dialog for the given
@@ -308,16 +336,19 @@ function BankSlots.bankSlotsPanelProto:OpenTabConfig(bagIndex)
     end
   end
 
+  local bankPanel = BankFrame and BankFrame.BankPanel or BankPanel
+  local accountBankPanel = BankFrame and BankFrame.AccountBankPanel or AccountBankPanel
+
   if isAccountTab then
-    -- Account/warbank tab: use AccountBankPanel.TabSettingsMenu
-    if AccountBankPanel and AccountBankPanel.TabSettingsMenu then
-      local menu = AccountBankPanel.TabSettingsMenu
+    -- Account/warbank tab: use AccountBankPanel.TabSettingsMenu or unified bankPanel.TabSettingsMenu
+    local menu = (accountBankPanel and accountBankPanel.TabSettingsMenu) or (bankPanel and bankPanel.TabSettingsMenu)
+    if menu then
       if bagFrame then
         menu:SetParent(bagFrame)
         menu:ClearAllPoints()
         menu:SetPoint("BOTTOMLEFT", bagFrame, "BOTTOMRIGHT", 10, 0)
         -- Keep GetBankFrame override so the menu can look up tab data via the
-        -- real AccountBankPanel hierarchy when needed.
+        -- real AccountBankPanel hierarchy when needed (for legacy frames).
         menu.GetBankFrame = function()
           return {
             GetTabData = function(_, id)
@@ -340,9 +371,9 @@ function BankSlots.bankSlotsPanelProto:OpenTabConfig(bagIndex)
       reconnectIconCallback(menu)
     end
   else
-    -- Character bank tab: use BankPanel.TabSettingsMenu (added in The War Within)
-    if BankPanel and BankPanel.TabSettingsMenu then
-      local menu = BankPanel.TabSettingsMenu
+    -- Character bank tab: use bankPanel.TabSettingsMenu (added in The War Within)
+    local menu = bankPanel and bankPanel.TabSettingsMenu
+    if menu then
       if bagFrame then
         menu:SetParent(bagFrame)
         menu:ClearAllPoints()
@@ -548,26 +579,8 @@ function BankSlots:CreatePanel(ctx, bagFrame)
 
   -- When fade-out finishes, clear the blizzardBankTab filter and restore normal view
   addon.HookScript(b.fadeOutGroup, "OnFinished", function(ectx)
-    -- Deselect all buttons
-    for _, btn in ipairs(b.buttons) do
-      btn:SetSelected(false)
-    end
-    b.selectedBagIndex = nil
-    -- Clear the single-tab filter and refresh the bank to show all items
-    if addon.Bags and addon.Bags.Bank then
-      addon.Bags.Bank.blizzardBankTab = nil
-      items:ClearBankCache(ectx)
-      events:SendMessage(ectx, 'bags/RefreshBank')
-    end
-    -- Restore panel anchor to above the bag frame (original position).
-    b.frame:ClearAllPoints()
-    b.frame:SetPoint("BOTTOMLEFT", bagFrame, "TOPLEFT", 0, 14)
-    -- Restore group tabs visibility to what it was before the panel opened.
-    local bankBag = addon.Bags and addon.Bags.Bank
-    if b.tabsWereShown and bankBag and bankBag.tabs then
-      bankBag.tabs.frame:Show()
-    end
-    b.tabsWereShown = false
+    b:OnClose(ectx)
+    events:SendMessage(ectx, 'bags/RefreshBank')
   end)
 
   -- Redraw when tab settings are updated (name/icon changed)
@@ -579,6 +592,12 @@ function BankSlots:CreatePanel(ctx, bagFrame)
 
   -- Redraw when a bank tab is purchased
   events:RegisterEvent('PLAYER_ACCOUNT_BANK_TAB_SLOTS_CHANGED', function(ectx)
+    if b:IsShown() then
+      b:Draw(ectx)
+    end
+  end)
+
+  events:RegisterEvent('PLAYER_BANK_TAB_SLOTS_CHANGED', function(ectx)
     if b:IsShown() then
       b:Draw(ectx)
     end

--- a/spec/frames/bankslots_spec.lua
+++ b/spec/frames/bankslots_spec.lua
@@ -113,6 +113,7 @@ _G.SetItemButtonQuality = function() end
 _G.SetItemButtonCount = function() end
 _G.SetItemButtonDesaturated = function() end
 _G.GetInventoryItemQuality = function() return 1 end
+_G.GetNumBankSlots = function() return 2 end
 _G.ItemButtonUtil = {
   Event = { ItemContextChanged = 1 },
   TriggerEvent = function() end,
@@ -295,6 +296,38 @@ describe("Bank Bag/Slot Window Pane Tests", function()
       -- Assertions: filter should be cleared, selectedBagIndex nil, buttons deselected
       assert.is_nil(mockBag.blizzardBankTab, "blizzardBankTab should be cleared on bank OnHide")
       assert.is_nil(panel.selectedBagIndex, "selectedBagIndex should be cleared on bank OnHide")
+    end)
+  end)
+
+  describe("6. Classic/Era OnClose Method Compatibility", function()
+    it("should safely handle bank OnHide on Classic/Era without OnClose nil errors", function()
+      addon.isRetail = false
+      local bagFrame = CreateFrame("Frame")
+
+      -- Load BagSlots and create Classic/Era panel
+      local bagSlots = addon:GetModule("BagSlots")
+      local panel = bagSlots:CreatePanel(ctx:New("test"), const.BAG_KIND.BANK, bagFrame)
+
+      local mockBag = {
+        frame = bagFrame,
+        moneyFrame = { Update = function() end },
+        tabs = {
+          SetClickHandler = function() end,
+          frame = { Show = function() end, IsShown = function() return true end }
+        },
+        slots = panel,
+        Wipe = function() end,
+      }
+
+      local bankBehavior = addon:GetModule("BankBehavior")
+      local bInstance = setmetatable({ bag = mockBag }, { __index = bankBehavior.proto })
+      addon.Bags = { Bank = mockBag }
+      mockBag.behavior = bInstance
+
+      -- Closing the bank on Classic/Era should not throw "attempt to call method 'OnClose' (a nil value)"
+      assert.has_no.errors(function()
+        bInstance:OnHide()
+      end)
     end)
   end)
 end)

--- a/spec/frames/bankslots_spec.lua
+++ b/spec/frames/bankslots_spec.lua
@@ -1,0 +1,300 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Load required modules
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("core/pool.lua")
+
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+addon.ForceHideBlizzardBags = function() end
+
+local ctx = addon:GetModule("Context")
+
+-- Stub standard dependencies
+local L = StubBetterBagsModule("Localization")
+L.G = function(_, key) return key end
+
+local database = StubBetterBagsModule("Database")
+database.GetShowBankTabs = function() return true end
+database.GetBagView = function() return 1 end
+database.SetBagView = function() end
+database.GetPreviousView = function() return 1 end
+database.SetPreviousView = function() end
+database.GetEnableBagFading = function() return false end
+
+local const = StubBetterBagsModule("Constants")
+const.BAG_KIND = { BACKPACK = 1, BANK = 2 }
+const.BACKPACK_ONLY_BAGS_LIST = { 1, 2, 3, 4 }
+const.BANK_ONLY_BAGS_LIST = { 5, 6, 7, 8 }
+const.BANK_ONLY_BAGS = { [5]=5, [6]=6, [7]=7, [8]=8 }
+const.BAG_VIEW = { SECTION_GRID = 1, SECTION_ALL_BAGS = 2 }
+const.OFFSETS = {
+  BAG_LEFT_INSET = 10,
+  BAG_TOP_INSET = -40,
+  BAG_RIGHT_INSET = -10,
+  BAG_BOTTOM_INSET = 10,
+}
+
+local items = StubBetterBagsModule("Items")
+items.ClearBankCache = function() end
+
+StubBetterBagsModule("Tabs")
+StubBetterBagsModule("Groups")
+StubBetterBagsModule("ContextMenu")
+
+local themes = StubBetterBagsModule("Themes")
+themes.RegisterFlatWindow = function() end
+themes.GetFlatHeaderHeight = function() return 12 end
+
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+
+local animations = StubBetterBagsModule("Animations")
+animations.AttachFadeAndSlideTop = function(region)
+  local mockAnimGroup = {
+    Play = function() end,
+    Stop = function() end,
+    HookScript = function() end,
+  }
+  return mockAnimGroup, mockAnimGroup
+end
+
+local grid = StubBetterBagsModule("Grid")
+grid.Create = function()
+  return {
+    GetContainer = function()
+      local container = CreateFrame("Frame")
+      return container
+    end,
+    HideScrollBar = function() end,
+    EnableMouseWheelScroll = function() end,
+    Show = function() end,
+    AddCell = function() end,
+    Draw = function() return 100, 100 end,
+    cells = {},
+  }
+end
+
+-- Define Enums if not set
+_G.Enum = _G.Enum or {}
+_G.Enum.BagIndex = _G.Enum.BagIndex or {
+  CharacterBankTab_1 = 10,
+  CharacterBankTab_6 = 15,
+  AccountBankTab_1 = 16,
+  AccountBankTab_2 = 17,
+  AccountBankTab_3 = 18,
+  AccountBankTab_4 = 19,
+  AccountBankTab_5 = 20,
+}
+_G.Enum.BankType = _G.Enum.BankType or {
+  Character = 1,
+  Account = 2,
+}
+
+_G.C_Bank = _G.C_Bank or {}
+_G.C_Bank.FetchPurchasedBankTabData = function(bankType)
+  if bankType == _G.Enum.BankType.Character then
+    return {
+      { ID = 10, icon = 1337 },
+    }
+  elseif bankType == _G.Enum.BankType.Account then
+    return {
+      { ID = 16, icon = 1338 },
+    }
+  end
+  return {}
+end
+
+_G.GetInventoryItemTexture = function() return 12345 end
+_G.SetItemButtonTexture = function() end
+_G.SetItemButtonQuality = function() end
+_G.SetItemButtonCount = function() end
+_G.SetItemButtonDesaturated = function() end
+_G.GetInventoryItemQuality = function() return 1 end
+_G.ItemButtonUtil = {
+  Event = { ItemContextChanged = 1 },
+  TriggerEvent = function() end,
+}
+
+_G.C_Container = _G.C_Container or {}
+_G.C_Container.ContainerIDToInventoryID = function(bagid) return bagid + 10 end
+
+-- Load modules
+LoadBetterBagsModule("frames/bagbutton.lua")
+LoadBetterBagsModule("frames/bagslots.lua")
+LoadBetterBagsModule("frames/bankslots.lua")
+LoadBetterBagsModule("frames/money.lua")
+LoadBetterBagsModule("bags/bank.lua")
+
+addon:GetModule("BagButton"):OnInitialize()
+
+describe("Bank Bag/Slot Window Pane Tests", function()
+  before_each(function()
+    _G.BankFrame = nil
+    _G.BankPanel = nil
+    _G.AccountBankPanel = nil
+    events:OnInitialize()
+  end)
+
+  describe("1. Classic/Era Event Typo (PLAYERBANKSLOTS_CHANGED)", function()
+    it("should register PLAYERBANKSLOTS_CHANGED instead of PLAYERBANKBAGSLOTS_CHANGED in frames/bagslots.lua", function()
+      addon.isRetail = false
+      local registeredEvents = {}
+      local oldRegisterEvent = events.RegisterEvent
+      events.RegisterEvent = function(self, event, fn)
+        registeredEvents[event] = true
+      end
+
+      local bagFrame = CreateFrame("Frame")
+      local bagSlots = addon:GetModule("BagSlots")
+      bagSlots:CreatePanel(ctx:New("test"), 1, bagFrame)
+
+      -- Restore
+      events.RegisterEvent = oldRegisterEvent
+
+      -- Assertions (reproduce the typo issue)
+      assert.is_nil(registeredEvents["PLAYERBANKBAGSLOTS_CHANGED"], "Should not register the typo event PLAYERBANKBAGSLOTS_CHANGED")
+      assert.is_true(registeredEvents["PLAYERBANKSLOTS_CHANGED"], "Should register correct event PLAYERBANKSLOTS_CHANGED")
+    end)
+  end)
+
+  describe("2. Retail Character Bank Tab Purchase Event Registration", function()
+    it("should register PLAYER_BANK_TAB_SLOTS_CHANGED in frames/bankslots.lua and bags/bank.lua", function()
+      addon.isRetail = true
+      local registeredEvents = {}
+      local oldRegisterEvent = events.RegisterEvent
+      events.RegisterEvent = function(self, event, fn)
+        registeredEvents[event] = true
+      end
+
+      -- Create panel
+      local bagFrame = CreateFrame("Frame")
+      local bankSlots = addon:GetModule("BankSlots")
+      bankSlots:CreatePanel(ctx:New("test"), bagFrame)
+
+      -- Load BankBehavior and register its events
+      local bankBehavior = addon:GetModule("BankBehavior")
+      local mockBag = {
+        frame = bagFrame,
+        moneyFrame = { Update = function() end },
+        tabs = { SetClickHandler = function() end },
+      }
+      local bInstance = setmetatable({ bag = mockBag }, { __index = bankBehavior.proto })
+      bInstance:RegisterEvents()
+
+      -- Restore
+      events.RegisterEvent = oldRegisterEvent
+
+      -- Assertions
+      assert.is_true(registeredEvents["PLAYER_BANK_TAB_SLOTS_CHANGED"], "PLAYER_BANK_TAB_SLOTS_CHANGED should be registered")
+    end)
+  end)
+
+  describe("3. Overwriting tabsWereShown State", function()
+    it("should not overwrite tabsWereShown to false on redundant Show calls", function()
+      addon.isRetail = true
+      local bagFrame = CreateFrame("Frame")
+      local bankSlots = addon:GetModule("BankSlots")
+      local panel = bankSlots:CreatePanel(ctx:New("test"), bagFrame)
+
+      -- Mock parent bag tabs frame
+      addon.Bags = {
+        Bank = {
+          tabs = {
+            frame = {
+              IsShown = function() return true end,
+              Hide = function() end,
+            }
+          }
+        }
+      }
+
+      panel:Show()
+      assert.is_true(panel.tabsWereShown)
+
+      -- Mock tabs hidden now
+      addon.Bags.Bank.tabs.frame.IsShown = function() return false end
+
+      -- Call Show again when already shown (IsShown returns true)
+      panel.frame.IsShown = function() return true end
+      panel:Show()
+
+      -- tabsWereShown should still be true!
+      assert.is_true(panel.tabsWereShown, "tabsWereShown should not be overwritten to false if panel is already shown")
+    end)
+  end)
+
+  describe("4. Warbank/Account Tab Right-Click Configuration Silent Failure", function()
+    it("should safely open configuration settings on right click with unified/legacy panel structures", function()
+      addon.isRetail = true
+      local bagFrame = CreateFrame("Frame")
+      local bankSlots = addon:GetModule("BankSlots")
+      local panel = bankSlots:CreatePanel(ctx:New("test"), bagFrame)
+
+      -- Let's mock a unified bankPanel (no global AccountBankPanel)
+      local mockMenu = CreateFrame("Frame")
+      mockMenu.IconSelector = {}
+      mockMenu.BorderBox = {
+        SelectedIconArea = {
+          SelectedIconButton = { SetIconTexture = function() end },
+        }
+      }
+      mockMenu.SetSelectedTab = function(self, id)
+        self.selectedTabData = { ID = id, icon = 1234 }
+      end
+      mockMenu.Update = spy.new(function() end)
+
+      _G.BankFrame = {
+        BankPanel = {
+          TabSettingsMenu = mockMenu
+        }
+      }
+
+      panel:OpenTabConfig(16) -- Warbank slot ID
+
+      -- Assertions
+      assert.spy(mockMenu.Update).was.called()
+      assert.is_not_nil(mockMenu.selectedTabData)
+    end)
+  end)
+
+  describe("5. Stuck Filter / blizzardBankTab Leak on Close", function()
+    it("should cleanly reset blizzardBankTab and button select state when closed", function()
+      addon.isRetail = true
+      local bagFrame = CreateFrame("Frame")
+      local bankSlots = addon:GetModule("BankSlots")
+      local panel = bankSlots:CreatePanel(ctx:New("test"), bagFrame)
+
+      local mockBag = {
+        frame = bagFrame,
+        moneyFrame = { Update = function() end },
+        tabs = {
+          SetClickHandler = function() end,
+          frame = { Show = function() end, IsShown = function() return true end }
+        },
+        slots = panel,
+        Wipe = function() end,
+        blizzardBankTab = 10,
+      }
+
+      local bankBehavior = addon:GetModule("BankBehavior")
+      local bInstance = setmetatable({ bag = mockBag }, { __index = bankBehavior.proto })
+      addon.Bags = { Bank = mockBag }
+      mockBag.behavior = bInstance
+
+      -- Select a tab, setting blizzardBankTab and selectedBagIndex
+      panel:SelectTab(ctx:New("test"), 10)
+      assert.are.equal(10, mockBag.blizzardBankTab)
+      assert.are.equal(10, panel.selectedBagIndex)
+
+      -- Hide the bank (reproducing the CloseBankFrame or UI Special Frame hide)
+      bInstance:OnHide()
+
+      -- Assertions: filter should be cleared, selectedBagIndex nil, buttons deselected
+      assert.is_nil(mockBag.blizzardBankTab, "blizzardBankTab should be cleared on bank OnHide")
+      assert.is_nil(panel.selectedBagIndex, "selectedBagIndex should be cleared on bank OnHide")
+    end)
+  end)
+end)

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -161,6 +161,13 @@ local function CreateMockWidget(widgetType, name, parent)
   function widget:SetTexture(path)
     self._texturePath = path
   end
+  function widget:SetTexCoord(...)
+    self._texCoords = {...}
+  end
+  function widget:SetAtlas(atlas, useAtlasSize)
+    self._atlas = atlas
+    self._useAtlasSize = useAtlasSize
+  end
   function widget:SetColorTexture(r, g, b, a)
     self._colorTexture = {r = r, g = g, b = b, a = a or 1}
   end
@@ -252,6 +259,14 @@ local function CreateMockWidget(widgetType, name, parent)
   end
   function widget:GetJustifyV()
     return self._justifyV
+  end
+
+  widget._attributes = {}
+  function widget:SetAttribute(name, value)
+    self._attributes[name] = value
+  end
+  function widget:GetAttribute(name)
+    return self._attributes[name]
   end
 
   -- Strata / Level / Backdrop

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -262,11 +262,11 @@ local function CreateMockWidget(widgetType, name, parent)
   end
 
   widget._attributes = {}
-  function widget:SetAttribute(name, value)
-    self._attributes[name] = value
+  function widget:SetAttribute(attrName, value)
+    self._attributes[attrName] = value
   end
-  function widget:GetAttribute(name)
-    return self._attributes[name]
+  function widget:GetAttribute(attrName)
+    return self._attributes[attrName]
   end
 
   -- Strata / Level / Backdrop


### PR DESCRIPTION
## Summary
This PR addresses several critical bugs in the bank bag/slot window pane logic across different game versions (Retail and Classic/Era).

- Fixed a typo preventing bank bag slots from updating on Classic/Era (`PLAYERBANKBAGSLOTS_CHANGED` -> `PLAYERBANKSLOTS_CHANGED`).
- Added registration for the Retail character bank tab purchase event (`PLAYER_BANK_TAB_SLOTS_CHANGED`) to correctly update the panel.
- Fixed a bug where closing the bank could permanently lock the filter to a single tab if the tab's fade-out animation was bypassed. The cleanup is now properly guaranteed in `OnHide`/`OnClose`.
- Fixed the silent failure when right-clicking a Warbank slot for configuration. This now correctly handles the unified `BankFrame.BankPanel` and its `TabSettingsMenu` instead of silently failing when `AccountBankPanel` is `nil`.
- Fixed an overwrite of `tabsWereShown` occurring during redundant `Show()` calls.
- Resolved a nil method crash (`OnClose`) for `BagSlots` in Classic/Era environments.

## Motivation
These bugs were causing significant functionality degradation:
- Warbank users could not access configuration options.
- Classic players purchasing bag slots weren't seeing updates visually without closing and reopening the bank.
- A stuck filter bug was causing items to mysteriously "disappear" from the bank UI.

## Testing and Validation
- **Test Suite (TDD):** Mocked the unified `BankFrame` and events, writing new failing test cases first. All fixes are verified under `busted` running on Lua 5.1 (via LuaJIT), ensuring there are no regressions.
- **Classic/Era Protection:** Re-verified functionality specific to Classic/Era (`GetNumBankSlots`, event registrations) in test mocks without WoW API errors.
- **Luacheck:** Re-ran `luacheck .` to ensure 0 linting warnings or errors. All 846 unit tests currently pass.