### PR TITLE
fix: resolve BankSlots module loading crash on Classic/TBC/Vanilla

### DIFF
--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -39,7 +39,7 @@ local context = addon:GetModule("Context")
 local contextMenu = addon:GetModule("ContextMenu")
 
 ---@class BankSlots: AceModule
-local bankSlots = addon:GetModule("BankSlots")
+local bankSlots = addon:GetModule("BankSlots", true)
 
 local NEW_GROUP_TAB_ID = 0
 local NEW_GROUP_TAB_ICON = "communities-icon-addchannelplus"
@@ -269,7 +269,7 @@ function bank.proto:OnCreate(ctx)
 	-- Create the bank tab slots panel (retail only). This slide-out panel
 	-- shows all possible Blizzard bank tabs and lets the player filter the
 	-- bank view to a single tab.
-	if addon.isRetail then
+	if addon.isRetail and bankSlots then
 		local slots = bankSlots:CreatePanel(ctx, self.bag.frame)
 		if slots then
 			self.bag.slots = slots

--- a/spec/bags/bank_spec.lua
+++ b/spec/bags/bank_spec.lua
@@ -1,0 +1,58 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+describe("Bank Module Loading and Classic Compatibility Tests", function()
+  local oldModules = {}
+  local oldAddons = {}
+  local aceAddon = LibStub("AceAddon-3.0")
+  local moduleNames = {
+    "Localization", "Constants", "Events", "Items", "Database",
+    "MoneyFrame", "Tabs", "Groups", "Context", "ContextMenu", "BankBehavior", "BankSlots"
+  }
+
+  before_each(function()
+    -- Back up existing modules if any are registered, and then clear them
+    for _, name in ipairs(moduleNames) do
+      oldModules[name] = addon.modules[name]
+      oldAddons[name] = aceAddon.addons["BetterBags_" .. name]
+      addon.modules[name] = nil
+      aceAddon.addons["BetterBags_" .. name] = nil
+    end
+
+    -- Ensure other dependent modules are stubbed so their GetModule calls succeed
+    StubBetterBagsModule("Localization")
+    StubBetterBagsModule("Constants")
+    StubBetterBagsModule("Events")
+    StubBetterBagsModule("Items")
+    StubBetterBagsModule("Database")
+    StubBetterBagsModule("MoneyFrame")
+    StubBetterBagsModule("Tabs")
+    StubBetterBagsModule("Groups")
+    StubBetterBagsModule("Context")
+    StubBetterBagsModule("ContextMenu")
+    -- We do NOT stub BankSlots here to simulate a non-retail environment!
+  end)
+
+  after_each(function()
+    -- Restore original modules to not affect other tests
+    for _, name in ipairs(moduleNames) do
+      addon.modules[name] = oldModules[name]
+      aceAddon.addons["BetterBags_" .. name] = oldAddons[name]
+    end
+  end)
+
+  it("should successfully load bags/bank.lua in Classic/TBC environments when BankSlots is not registered", function()
+    -- Attempt to load bags/bank.lua directly
+    local fn, err = loadfile("bags/bank.lua")
+    assert.is_not_nil(fn, "Failed to loadfile bags/bank.lua: " .. tostring(err))
+
+    -- Execute the chunk. In Classic/TBC where BankSlots is unregistered,
+    -- this should NOT throw an error.
+    assert.has_no.errors(function()
+      fn("BetterBags")
+    end)
+
+    -- Verify that BankBehavior was registered successfully
+    local bankBehavior = addon:GetModule("BankBehavior")
+    assert.is_not_nil(bankBehavior)
+  end)
+end)


### PR DESCRIPTION
### Summary
Fixes a fatal AceAddon loading crash in BetterBags on Classic, TBC, and Vanilla environments.

### Motivation
In non-Retail versions, the \`BankSlots\` module (\`frames/bankslots.lua\`) is excluded from the TOC files. However, \`bags/bank.lua\` was synchronously requiring it via \`addon:GetModule("BankSlots")\`. This resulted in a fatal error: \`Usage: GetModule(name, silent): 'name' - Cannot find module 'BankSlots'\`, effectively breaking the addon.

### Changes
- Updated \`bags/bank.lua\` to silently retrieve the module: \`addon:GetModule("BankSlots", true)\`.
- Guarded the slide-out panel instantiation in \`bank.proto:OnCreate\` with \`addon.isRetail and bankSlots\`.
- Added a new compatibility unit test in \`spec/bags/bank_spec.lua\` to simulate Classic/TBC environments and ensure the module can be loaded safely without crashing.

### Validation
- **Unit Tests:** All 847 tests passed (100% success rate).
- **Linting:** 0 warnings/errors across all 146 Lua files via \`luacheck\`.