### PR TITLE
fix: resolve nil-indexing database crash in Classic and Era bags

### DIFF
--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -39,7 +39,7 @@ local context = addon:GetModule("Context")
 local contextMenu = addon:GetModule("ContextMenu")
 
 ---@class BankSlots: AceModule
-local bankSlots = addon:GetModule("BankSlots")
+local bankSlots = addon:GetModule("BankSlots", true)
 
 local NEW_GROUP_TAB_ID = 0
 local NEW_GROUP_TAB_ICON = "communities-icon-addchannelplus"
@@ -269,7 +269,7 @@ function bank.proto:OnCreate(ctx)
 	-- Create the bank tab slots panel (retail only). This slide-out panel
 	-- shows all possible Blizzard bank tabs and lets the player filter the
 	-- bank view to a single tab.
-	if addon.isRetail then
+	if addon.isRetail and bankSlots then
 		local slots = bankSlots:CreatePanel(ctx, self.bag.frame)
 		if slots then
 			self.bag.slots = slots

--- a/bags/classic/backpack.lua
+++ b/bags/classic/backpack.lua
@@ -26,7 +26,7 @@ function backpack.proto:OnCreate(ctx)
 	-- Classic: Search frame, bag slots, currency, and theme config are created inline in frames/classic/bag.lua
 
 	-- Group tabs
-	self.bag.tabs = tabs:Create(self.bag.frame)
+	self.bag.tabs = tabs:Create(self.bag.frame, const.BAG_KIND.BACKPACK)
 
 	-- Set up tab click handler
 	local behavior = self

--- a/bags/era/backpack.lua
+++ b/bags/era/backpack.lua
@@ -28,7 +28,7 @@ function backpack.proto:OnCreate(ctx)
 	-- Currency doesn't exist in Era (no GetCurrencyListInfo API)
 
 	-- Group tabs
-	self.bag.tabs = tabs:Create(self.bag.frame)
+	self.bag.tabs = tabs:Create(self.bag.frame, const.BAG_KIND.BACKPACK)
 
 	-- Set up tab click handler
 	local behavior = self

--- a/core/database.lua
+++ b/core/database.lua
@@ -652,6 +652,7 @@ end
 ---@param kind BagKind
 ---@return table<number, Group>
 function DB:GetAllGroups(kind)
+  if not kind or not DB.data.profile.groups[kind] then return {} end
   return DB.data.profile.groups[kind]
 end
 
@@ -659,6 +660,7 @@ end
 ---@param groupID number
 ---@return Group?
 function DB:GetGroup(kind, groupID)
+  if not kind or not DB.data.profile.groups[kind] then return nil end
   return DB.data.profile.groups[kind][groupID]
 end
 

--- a/spec/bags/backpack_spec.lua
+++ b/spec/bags/backpack_spec.lua
@@ -1,0 +1,281 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+local aceAddon = LibStub("AceAddon-3.0")
+_G.PanelTemplates_TabResize = _G.PanelTemplates_TabResize or function() end
+_G.GetAppropriateTooltip = _G.GetAppropriateTooltip or function() return GameTooltip end
+_G.GameTooltip.IsOwned = _G.GameTooltip.IsOwned or function() return false end
+
+describe("Backpack Module Loading and Compatibility Tests", function()
+  local oldModules = {}
+  local oldAddons = {}
+  local oldGetTabButton
+
+  before_each(function()
+    -- Only clear BackpackBehavior so we can load it fresh for era/classic behavior
+    oldModules["BackpackBehavior"] = addon.modules["BackpackBehavior"]
+    oldAddons["BackpackBehavior"] = aceAddon.addons["BetterBags_BackpackBehavior"]
+    addon.modules["BackpackBehavior"] = nil
+    aceAddon.addons["BetterBags_BackpackBehavior"] = nil
+
+    -- Stub other dependent modules so they are guaranteed to exist
+    local L = StubBetterBagsModule("Localization")
+    L.data = {}
+    L.locale = "enUS"
+    function L:G(key) return key end
+
+    local const = StubBetterBagsModule("Constants")
+    const.BAG_KIND = { BACKPACK = 0, BANK = 1, UNDEFINED = -1 }
+    const.BAG_VIEW = { UNDEFINED = 0, ONE_BAG = 1, SECTION_GRID = 2, LIST = 3, SECTION_ALL_BAGS = 4 }
+    const.SECTION_SORT_TYPE = { ALPHABETICALLY = 1, SIZE_DESCENDING = 2, SIZE_ASCENDING = 3 }
+    const.ITEM_SORT_TYPE = { ALPHABETICALLY_THEN_QUALITY = 1, QUALITY_THEN_ALPHABETICALLY = 2, ITEM_LEVEL = 3, EXPANSION = 4 }
+    const.GRID_COMPACT_STYLE = { NONE = 0, SIMPLE = 1, COMPACT = 2 }
+    const.SEARCH_CATEGORY_GROUP_BY = { NONE = 0, TYPE = 1, SUBTYPE = 2, EXPANSION = 3 }
+    const.FORM_LAYOUT = { TWO_COLUMN = 1, STACKED = 2 }
+    const.BINDING_SCOPE = {}
+    const.BINDING_MAP = {}
+    const.DATABASE_DEFAULTS = {
+      profile = {
+        firstTimeMenu = true,
+        enabled = true,
+        enableBagFading = false,
+        showBagButton = true,
+        enableBankBag = true,
+        showBankTabs = false,
+        debug = false,
+        inBagSearch = true,
+        categorySell = false,
+        showKeybindWarning = true,
+        enterToMakeCategory = true,
+        upgradeIconProvider = 'None',
+        theme = 'Default',
+        showFullSectionNames = { [0] = false, [1] = false },
+        showAllFreeSpace = { [0] = false, [1] = false },
+        extraGlowyButtons = { [0] = false, [1] = false },
+        newItems = {
+          [0] = { markRecentItems = true, showNewItemFlash = false },
+          [1] = { markRecentItems = true, showNewItemFlash = false },
+        },
+        stacking = {
+          [0] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+          [1] = { mergeStacks = true, mergeUnstackable = true, unmergeAtShop = true, dontMergePartial = false, dontMergeTransmog = false },
+        },
+        itemLevel = {
+          [0] = { enabled = true, color = true },
+          [1] = { enabled = true, color = true },
+        },
+        itemLevelColor = {
+          maxItemLevelByCharacter = {},
+          colors = {
+            low = { red = 0.62, green = 0.62, blue = 0.62, alpha = 1 },
+            mid = { red = 1, green = 1, blue = 1, alpha = 1 },
+            high = { red = 0, green = 0.55, blue = 0.87, alpha = 1 },
+            max = { red = 1, green = 0.5, blue = 0, alpha = 1 },
+          }
+        },
+        positions = { [0] = {}, [1] = {} },
+        anchorPositions = { [0] = {}, [1] = {} },
+        anchorState = {
+          [0] = { enabled = false, shown = false },
+          [1] = { enabled = false, shown = false },
+        },
+        sectionSort = {
+          [0] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 },
+          [1] = { [1] = 1, [2] = 1, [3] = 1, [4] = 1 },
+        },
+        itemSort = {
+          [0] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 },
+          [1] = { [1] = 2, [2] = 2, [3] = 2, [4] = 2 },
+        },
+        customSectionSort = { [0] = {}, [1] = {} },
+        collapsedSections = { [0] = {}, [1] = {} },
+        size = {
+          [1] = {
+            [0] = { columnCount = 15, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+            [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+          },
+          [2] = {
+            [0] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+            [1] = { columnCount = 2, itemsPerRow = 7, scale = 100, width = 700, height = 500, opacity = 89 },
+          },
+          [3] = {
+            [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+            [1] = { columnCount = 5, itemsPerRow = 5, scale = 100, width = 700, height = 500, opacity = 89 },
+          },
+          [4] = {
+            [0] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+            [1] = { columnCount = 1, itemsPerRow = 15, scale = 100, width = 700, height = 500, opacity = 89 },
+          },
+        },
+        views = { [0] = 2, [1] = 2 },
+        previousViews = { [0] = 2, [1] = 2 },
+        categoryOptions = {},
+        customCategoryFilters = {},
+        ephemeralCategoryFilters = {},
+        customCategoryIndex = {},
+        categoryFilters = {
+          [0] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+          [1] = { Type = true, Subtype = false, Expansion = false, TradeSkill = false, RecentItems = true, GearSet = true, EquipmentLocation = true },
+        },
+        lockedItems = {},
+        newItemTime = 300,
+        groups = {
+          [0] = { [1] = { id = 1, name = "Backpack", order = 1, kind = 0, isDefault = true } },
+          [1] = {},
+        },
+        groupCounter = { [0] = 1, [1] = 0 },
+        categoryToGroup = { [0] = {}, [1] = {} },
+        activeGroup = { [0] = 1, [1] = 1 },
+        groupsEnabled = { [0] = true, [1] = true },
+        __profileSystemMigrated = false,
+      },
+      char = {},
+    }
+
+    StubBetterBagsModule("Events")
+    local events = addon:GetModule("Events")
+    events.OnInitialize = events.OnInitialize or function() end
+    events.SendMessage = events.SendMessage or function() end
+    events.BucketEvent = events.BucketEvent or function() end
+    events.RegisterMessage = events.RegisterMessage or function() end
+
+    StubBetterBagsModule("Debug")
+    local debug = addon:GetModule("Debug")
+    debug.Log = function() end
+    debug.Inspect = function() end
+
+    StubBetterBagsModule("BagSlots")
+    local slots = addon:GetModule("BagSlots")
+    slots.CreatePanel = slots.CreatePanel or function()
+      return { frame = CreateFrame("Frame") }
+    end
+
+    StubBetterBagsModule("SearchBox")
+    local search = addon:GetModule("SearchBox")
+    search.Create = search.Create or function()
+      return CreateFrame("Frame")
+    end
+
+    StubBetterBagsModule("Currency")
+    local currency = addon:GetModule("Currency")
+    currency.CreateIconGrid = currency.CreateIconGrid or function()
+      return CreateFrame("Frame")
+    end
+
+    StubBetterBagsModule("ThemeConfig")
+    local tc = addon:GetModule("ThemeConfig")
+    tc.Create = tc.Create or function()
+      return CreateFrame("Frame")
+    end
+
+    StubBetterBagsModule("MoneyFrame")
+    local money = addon:GetModule("MoneyFrame")
+    money.Create = money.Create or function()
+      return { frame = CreateFrame("Frame") }
+    end
+
+    StubBetterBagsModule("ContextMenu")
+    StubBetterBagsModule("SectionFrame")
+
+    -- Load real Context, Database, Groups, Tabs
+    ResetModuleStub("Context", "core/context.lua")
+    LoadBetterBagsModule("core/context.lua")
+    LoadBetterBagsModule("core/database.lua")
+    LoadBetterBagsModule("data/groups.lua")
+
+    -- Mock/Stub Themes before loading Tabs
+    local themes = StubBetterBagsModule("Themes")
+    oldGetTabButton = themes.GetTabButton
+    themes.GetTabButton = function(self, ctx, tab)
+      local decoration = CreateFrame("Button")
+      decoration.Enable = decoration.Enable or function() end
+      decoration.Disable = decoration.Disable or function() end
+      decoration.SetDisabledFontObject = decoration.SetDisabledFontObject or function() end
+      decoration.Text = decoration:CreateFontString()
+      decoration.Text.SetFontObject = decoration.Text.SetFontObject or function() end
+      decoration.Left = decoration:CreateTexture()
+      decoration.Middle = decoration:CreateTexture()
+      decoration.Right = decoration:CreateTexture()
+      decoration.LeftActive = decoration:CreateTexture()
+      decoration.MiddleActive = decoration:CreateTexture()
+      decoration.RightActive = decoration:CreateTexture()
+      return decoration
+    end
+
+    LoadBetterBagsModule("frames/tabs.lua")
+
+    -- Setup database defaults
+    local DB = addon:GetModule("Database")
+    DB.Migrate = function() end
+    DB:OnInitialize()
+    DB.data:ResetProfile(false, true)
+  end)
+
+  after_each(function()
+    -- Restore themes
+    local themes = addon:GetModule("Themes")
+    themes.GetTabButton = oldGetTabButton
+
+    -- Restore original modules to not affect other tests
+    addon.modules["BackpackBehavior"] = oldModules["BackpackBehavior"]
+    aceAddon.addons["BetterBags_BackpackBehavior"] = oldAddons["BackpackBehavior"]
+  end)
+
+  it("should successfully run era backpack OnCreate without crashes", function()
+    -- Load base backpack behavior using loadfile directly to bypass load-once logic
+    local loadBase = assert(loadfile("bags/backpack.lua"))
+    loadBase("BetterBags")
+    local backpack = addon:GetModule("BackpackBehavior")
+
+    -- Load era override
+    local fn, err = loadfile("bags/era/backpack.lua")
+    assert.is_not_nil(fn, "Failed to loadfile bags/era/backpack.lua: " .. tostring(err))
+    fn("BetterBags")
+
+    -- Create fresh backpack behavior instance
+    local parentFrame = CreateFrame("Frame", "BetterBagsBackpack")
+    parentFrame.GetFrameLevel = function() return 10 end
+    parentFrame.GetFrameStrata = function() return "MEDIUM" end
+
+    local mockBag = {
+      frame = parentFrame,
+      tabsResizedAfterLoad = false,
+    }
+    local behavior = backpack:Create(mockBag)
+
+    -- Call OnCreate on the era-overridden backpack behavior
+    -- Inside OnCreate, it calls: self.bag.tabs = tabs:Create(self.bag.frame) (pre-fix, missing BAG_KIND)
+    -- This should not crash if kind is handled or if we applied the fix.
+    assert.has_no.errors(function()
+      behavior:OnCreate({})
+    end)
+  end)
+
+  it("should successfully run classic backpack OnCreate without crashes", function()
+    -- Load base backpack behavior using loadfile directly to bypass load-once logic
+    local loadBase = assert(loadfile("bags/backpack.lua"))
+    loadBase("BetterBags")
+    local backpack = addon:GetModule("BackpackBehavior")
+
+    -- Load classic override
+    local fn, err = loadfile("bags/classic/backpack.lua")
+    assert.is_not_nil(fn, "Failed to loadfile bags/classic/backpack.lua: " .. tostring(err))
+    fn("BetterBags")
+
+    -- Create fresh backpack behavior instance
+    local parentFrame = CreateFrame("Frame", "BetterBagsBackpack")
+    parentFrame.GetFrameLevel = function() return 10 end
+    parentFrame.GetFrameStrata = function() return "MEDIUM" end
+
+    local mockBag = {
+      frame = parentFrame,
+      tabsResizedAfterLoad = false,
+    }
+    local behavior = backpack:Create(mockBag)
+
+    -- Call OnCreate on the classic-overridden backpack behavior
+    -- Inside OnCreate, it calls: self.bag.tabs = tabs:Create(self.bag.frame) (pre-fix, missing BAG_KIND)
+    -- This should not crash if kind is handled or if we applied the fix.
+    assert.has_no.errors(function()
+      behavior:OnCreate({})
+    end)
+  end)
+end)

--- a/spec/bags/bank_spec.lua
+++ b/spec/bags/bank_spec.lua
@@ -1,0 +1,58 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+describe("Bank Module Loading and Classic Compatibility Tests", function()
+  local oldModules = {}
+  local oldAddons = {}
+  local aceAddon = LibStub("AceAddon-3.0")
+  local moduleNames = {
+    "Localization", "Constants", "Events", "Items", "Database",
+    "MoneyFrame", "Tabs", "Groups", "Context", "ContextMenu", "BankBehavior", "BankSlots"
+  }
+
+  before_each(function()
+    -- Back up existing modules if any are registered, and then clear them
+    for _, name in ipairs(moduleNames) do
+      oldModules[name] = addon.modules[name]
+      oldAddons[name] = aceAddon.addons["BetterBags_" .. name]
+      addon.modules[name] = nil
+      aceAddon.addons["BetterBags_" .. name] = nil
+    end
+
+    -- Ensure other dependent modules are stubbed so their GetModule calls succeed
+    StubBetterBagsModule("Localization")
+    StubBetterBagsModule("Constants")
+    StubBetterBagsModule("Events")
+    StubBetterBagsModule("Items")
+    StubBetterBagsModule("Database")
+    StubBetterBagsModule("MoneyFrame")
+    StubBetterBagsModule("Tabs")
+    StubBetterBagsModule("Groups")
+    StubBetterBagsModule("Context")
+    StubBetterBagsModule("ContextMenu")
+    -- We do NOT stub BankSlots here to simulate a non-retail environment!
+  end)
+
+  after_each(function()
+    -- Restore original modules to not affect other tests
+    for _, name in ipairs(moduleNames) do
+      addon.modules[name] = oldModules[name]
+      aceAddon.addons["BetterBags_" .. name] = oldAddons[name]
+    end
+  end)
+
+  it("should successfully load bags/bank.lua in Classic/TBC environments when BankSlots is not registered", function()
+    -- Attempt to load bags/bank.lua directly
+    local fn, err = loadfile("bags/bank.lua")
+    assert.is_not_nil(fn, "Failed to loadfile bags/bank.lua: " .. tostring(err))
+
+    -- Execute the chunk. In Classic/TBC where BankSlots is unregistered,
+    -- this should NOT throw an error.
+    assert.has_no.errors(function()
+      fn("BetterBags")
+    end)
+
+    -- Verify that BankBehavior was registered successfully
+    local bankBehavior = addon:GetModule("BankBehavior")
+    assert.is_not_nil(bankBehavior)
+  end)
+end)

--- a/spec/database_spec.lua
+++ b/spec/database_spec.lua
@@ -891,6 +891,16 @@ describe("Database", function()
       assert.is_nil(DB:GetGroup(const.BAG_KIND.BANK, 999))
     end)
 
+    it("GetAllGroups handles nil kind gracefully", function()
+      local groups = DB:GetAllGroups(nil)
+      assert.same({}, groups)
+    end)
+
+    it("GetGroup handles nil kind gracefully", function()
+      local group = DB:GetGroup(nil, 1)
+      assert.is_nil(group)
+    end)
+
     it("CreateGroup creates a new group and returns its ID", function()
       local id = DB:CreateGroup(const.BAG_KIND.BACKPACK, "Test Group")
       assert.are.equal(2, id)

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -273,8 +273,14 @@ local function CreateMockWidget(widgetType, name, parent)
   function widget:SetFrameStrata(strata)
     self._frameStrata = strata
   end
+  function widget:GetFrameStrata()
+    return self._frameStrata or "MEDIUM"
+  end
   function widget:SetFrameLevel(level)
     self._frameLevel = level
+  end
+  function widget:GetFrameLevel()
+    return self._frameLevel or 1
   end
   function widget:SetBackdrop(backdrop)
     self._backdrop = backdrop
@@ -552,8 +558,8 @@ _G.GetCursorPosition = function() return _G._cursorX or 0, _G._cursorY or 0 end
 -- Enum Setup
 _G.Enum = _G.Enum or {}
 _G.Enum.BankType = {
-  Account = 1,
-  Character = 2,
+  Character = 1,
+  Account = 2,
 }
 _G.Enum.BagIndex = {
   Keyring = -2,


### PR DESCRIPTION
### Summary
Fixes a \`nil\` indexing crash occurring in \`core/database.lua:662\` for Classic, TBC, and Vanilla environments when processing bag tabs without a defined \`kind\`.

### Motivation
In the Classic and Era overrides, \`tabs:Create\` was invoked without passing a \`BAG_KIND\`. This propagated a \`nil\` bag kind down through \`IsTabReorderable\` -> \`IsDefaultGroup\` -> \`database:GetGroup\`, which then threw an \`attempt to index field '?' (a nil value)\` when attempting to index \`DB.data.profile.groups[kind][groupID]\`.

### Changes & Validation
- Passed \`const.BAG_KIND.BACKPACK\` during tab creation in \`bags/classic/backpack.lua\` and \`bags/era/backpack.lua\`.
- Added defensive nil guards to \`GetAllGroups\` and \`GetGroup\` in \`core/database.lua\`.
- Corrected inverted \`_G.Enum.BankType\` values in \`spec/helpers/wow_mocks.lua\` to fix pre-existing tests.
- Added TDD coverage for backpack initialization in \`spec/bags/backpack_spec.lua\` and DB nil-guards in \`spec/database_spec.lua\`.
- Validated with 100% test pass rate locally (\`busted\`) and 0 linter warnings (\`luacheck .\`).