### PR TITLE
fix: restore group tabs on slots panel close if groups are enabled

### DIFF
--- a/frames/bagslots.lua
+++ b/frames/bagslots.lua
@@ -118,7 +118,7 @@ end
 ---@param _ctx Context
 function BagSlots.bagSlotProto:OnClose(_ctx)
   local parentBag = addon.Bags and (self.kind == const.BAG_KIND.BACKPACK and addon.Bags.Backpack or addon.Bags.Bank)
-  if self.tabsWereShown and parentBag and parentBag.tabs then
+  if (self.tabsWereShown or database:GetGroupsEnabled(self.kind)) and parentBag and parentBag.tabs then
     parentBag.tabs.frame:Show()
   end
   self.tabsWereShown = false
@@ -177,7 +177,7 @@ function BagSlots:CreatePanel(ctx, kind, bagFrame)
     b.frame:SetPoint("BOTTOMLEFT", bagFrame, "TOPLEFT", 0, 14)
 
     local parentBag = addon.Bags and (kind == const.BAG_KIND.BACKPACK and addon.Bags.Backpack or addon.Bags.Bank)
-    if b.tabsWereShown and parentBag and parentBag.tabs then
+    if (b.tabsWereShown or database:GetGroupsEnabled(kind)) and parentBag and parentBag.tabs then
       parentBag.tabs.frame:Show()
     end
     b.tabsWereShown = false

--- a/frames/bankslots.lua
+++ b/frames/bankslots.lua
@@ -35,6 +35,9 @@ local themes = addon:GetModule('Themes')
 ---@class Context: AceModule
 local context = addon:GetModule('Context')
 
+---@class Database: AceModule
+local database = addon:GetModule('Database')
+
 local buttonCount = 0
 
 -- BankSlotButton represents a single bank tab slot button in the panel.
@@ -272,7 +275,7 @@ function BankSlots.bankSlotsPanelProto:OnClose(ctx)
   self.frame:SetPoint("BOTTOMLEFT", self.bagFrame, "TOPLEFT", 0, 14)
   -- Restore group tabs visibility to what it was before the panel opened.
   local bankBag = addon.Bags and addon.Bags.Bank
-  if self.tabsWereShown and bankBag and bankBag.tabs then
+  if (self.tabsWereShown or database:GetGroupsEnabled(const.BAG_KIND.BANK)) and bankBag and bankBag.tabs then
     bankBag.tabs.frame:Show()
   end
   self.tabsWereShown = false

--- a/frames/era/bagslots.lua
+++ b/frames/era/bagslots.lua
@@ -89,7 +89,7 @@ function BagSlots:CreatePanel(ctx, kind, bagFrame)
     b.frame:SetPoint("BOTTOMLEFT", bagFrame, "TOPLEFT", 0, 14)
 
     local parentBag = addon.Bags and (kind == const.BAG_KIND.BACKPACK and addon.Bags.Backpack or addon.Bags.Bank)
-    if b.tabsWereShown and parentBag and parentBag.tabs then
+    if (b.tabsWereShown or database:GetGroupsEnabled(kind)) and parentBag and parentBag.tabs then
       parentBag.tabs.frame:Show()
     end
     b.tabsWereShown = false

--- a/spec/frames/bankslots_spec.lua
+++ b/spec/frames/bankslots_spec.lua
@@ -23,6 +23,7 @@ database.SetBagView = function() end
 database.GetPreviousView = function() return 1 end
 database.SetPreviousView = function() end
 database.GetEnableBagFading = function() return false end
+database.GetGroupsEnabled = function() return true end
 
 local const = StubBetterBagsModule("Constants")
 const.BAG_KIND = { BACKPACK = 1, BANK = 2 }
@@ -328,6 +329,34 @@ describe("Bank Bag/Slot Window Pane Tests", function()
       assert.has_no.errors(function()
         bInstance:OnHide()
       end)
+    end)
+  end)
+
+  describe("7. Restore Group Tabs even if tabsWereShown was false (Bugfix)", function()
+    it("should restore group tabs on close if groups are enabled, even if tabsWereShown is false", function()
+      addon.isRetail = true
+      local bagFrame = CreateFrame("Frame")
+      local bankSlots = addon:GetModule("BankSlots")
+      local panel = bankSlots:CreatePanel(ctx:New("test"), bagFrame)
+
+      local tabsShown = false
+      addon.Bags = {
+        Bank = {
+          tabs = {
+            frame = {
+              IsShown = function() return false end,
+              Show = function() tabsShown = true end,
+              Hide = function() end,
+            }
+          }
+        }
+      }
+
+      panel.tabsWereShown = false
+      database.GetGroupsEnabled = function(_, kind) return true end
+
+      panel:OnClose(ctx:New("test"))
+      assert.is_true(tabsShown, "group tabs should have been shown on close because groups are enabled")
     end)
   end)
 end)


### PR DESCRIPTION
### Summary
This PR fixes an issue where group tabs (Bank, Warbank, any configured) would disappear and fail to show after toggling "Show Bags" off in the bank. The fix introduces a database-driven fallback check in `frames/bankslots.lua`, `frames/bagslots.lua`, and `frames/era/bagslots.lua` that correctly restores the group tabs frame when the slots panel is closed if groups are enabled.

### Motivation
On a fresh load/reload with "Show Bags" enabled, early `GenerateGroupTabs` pre-hides the group tabs. When the slot panel is shown immediately after, it captures `self.tabsWereShown = false`. If the user then toggles "Show Bags" off, `OnClose` sees `self.tabsWereShown` as false and never shows the tabs again, leaving the user with missing group tabs. This PR ensures the tabs are correctly shown by using a robust fallback to check if groups are enabled in the database.

### Testing and Validation
- **Unit Testing**: Added a new TDD unit test in `spec/frames/bankslots_spec.lua` to simulate a fresh load where `tabsWereShown` is `false` but groups are enabled. The test failed correctly before the fix and passes completely with the new fallback logic.
- **Linting**: Executed `luacheck` on the modified files (`frames/bankslots.lua`, `frames/bagslots.lua`, `frames/era/bagslots.lua`, and `spec/frames/bankslots_spec.lua`) and confirmed 100% clean results (0 warnings, 0 errors).
- **Manual Validation equivalent**: Verified that the fallback check aligns with the application state models and WoW UI mocks.
