### PR TITLE
Refactor: Implement persistent tab-scoped views to prevent nil slotkey crash

### DIFF
--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -253,8 +253,7 @@ function bank.proto:SwitchToBlizzardTab(ctx, bagIndex)
 
 	self.bag.currentItemCount = -1
 	items:ClearBankCache(ctx)
-	self.bag:Wipe(ctx)
-	ctx:Set("wipe", true)
+	ctx:Set("redraw", true)
 	events:SendMessage(ctx, "bags/RefreshBank")
 	ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
 end
@@ -567,8 +566,7 @@ function bank.proto:SwitchToGroup(ctx, groupID)
 	self.bag.currentItemCount = -1
 
 	items:ClearBankCache(ctx)
-	self.bag:Wipe(ctx)
-	ctx:Set("wipe", true)
+	ctx:Set("redraw", true)
 
 	events:SendMessage(ctx, "bags/RefreshBank")
 	ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)

--- a/data/items.lua
+++ b/data/items.lua
@@ -588,7 +588,21 @@ function items:RefreshBags(ctx, kind)
 		-- If the bank slots panel has selected a specific Blizzard tab, only
 		-- load items from that single bag index instead of all bank bags.
 		local blizzardTab = addon.Bags.Bank and addon.Bags.Bank.blizzardBankTab
-		if blizzardTab and addon.isRetail then
+		if database:GetShowBankTabs() and addon.isRetail then
+			-- When bank tabs setting is enabled in Retail, we load ALL bank bags (both Character and Account)
+			-- so that persistent tab-scoped views can filter and display them correctly.
+			ctx:Set("bagid", const.BANK_TAB.BANK)
+			for _, bag in pairs(const.BANK_BAGS) do
+				bagList[bag] = bag
+			end
+			for _, bag in pairs(const.ACCOUNT_BANK_BAGS) do
+				bagList[bag] = bag
+			end
+			local reagentBank = not addon.isRetail and const.BANK_TAB.REAGENT or nil
+			if reagentBank then
+				bagList[reagentBank] = reagentBank
+			end
+		elseif blizzardTab and addon.isRetail then
 			if Enum.BagIndex.AccountBankTab_1 and blizzardTab >= Enum.BagIndex.AccountBankTab_1 then
 				ctx:Set("bagid", const.BANK_TAB.ACCOUNT_BANK_1)
 			else

--- a/frames/bag.lua
+++ b/frames/bag.lua
@@ -158,6 +158,22 @@ function bagFrame.bagProto:Wipe(ctx)
 	end
 end
 
+---@param ctx Context
+---@param tabID number
+function bagFrame.bagProto:DeleteTabView(ctx, tabID)
+	if not self.tabViews then return end
+	local layouts = {const.BAG_VIEW.SECTION_GRID, const.BAG_VIEW.SECTION_ALL_BAGS}
+	for _, layout in ipairs(layouts) do
+		local viewKey = layout .. "_" .. tostring(tabID)
+		local view = self.tabViews[viewKey]
+		if view then
+			view:Wipe(ctx)
+			view:GetContent():Wipe()
+			self.tabViews[viewKey] = nil
+		end
+	end
+end
+
 ---@return string
 function bagFrame.bagProto:GetName()
 	return self.frame:GetName()
@@ -191,20 +207,46 @@ function bagFrame.bagProto:ResetSearch(ctx)
 	end
 end
 
+function bagFrame.bagProto:GetCurrentTabID()
+	if self.kind == const.BAG_KIND.BANK and database:GetShowBankTabs() then
+		return self.blizzardBankTab or -1
+	end
+	if database:GetGroupsEnabled(self.kind) then
+		return database:GetActiveGroup(self.kind) or 1
+	end
+	return 1
+end
+
+function bagFrame.bagProto:GetViewForTab(_, tabID)
+	local layout = database:GetBagView(self.kind)
+	local viewKey = layout .. "_" .. tostring(tabID)
+	if not self.tabViews then
+		self.tabViews = {}
+	end
+	if not self.tabViews[viewKey] then
+		if layout == const.BAG_VIEW.SECTION_GRID then
+			self.tabViews[viewKey] = views:NewGrid(self.frame, self.kind, tabID)
+		else
+			self.tabViews[viewKey] = views:NewBagView(self.frame, self.kind, tabID)
+		end
+	end
+	return self.tabViews[viewKey]
+end
+
 -- Draw will draw the correct bag view based on the bag view configuration.
 ---@param ctx Context
 ---@param slotInfo SlotInfo
 ---@param callback fun()
 function bagFrame.bagProto:Draw(ctx, slotInfo, callback)
-	local view = self.views[database:GetBagView(self.kind)]
+	local tabID = self:GetCurrentTabID()
+	local view = self:GetViewForTab(ctx, tabID)
 
 	if view == nil then
 		assert(view, "No view found for bag view: " .. database:GetBagView(self.kind))
 		return
 	end
 
-	if self.currentView and self.currentView:GetBagView() ~= view:GetBagView() then
-		self.currentView:Wipe(ctx)
+	if self.currentView and self.currentView ~= view then
 		self.currentView:GetContent():Hide()
 	end
 
@@ -420,10 +462,7 @@ function bagFrame:Create(ctx, kind)
 	--  if b.kind == const.BAG_KIND.BANK then CloseBankFrame() end
 	--end)
 
-	b.views = {
-		[const.BAG_VIEW.SECTION_GRID] = views:NewGrid(f, b.kind),
-		[const.BAG_VIEW.SECTION_ALL_BAGS] = views:NewBagView(f, b.kind),
-	}
+	b.tabViews = {}
 
 	-- Register the bag frame so that window positions are saved.
 	Window.RegisterConfig(b.frame, database:GetBagPosition(kind))
@@ -499,6 +538,12 @@ function bagFrame:Create(ctx, kind)
 		end
 		for _, item in pairs(b.currentView:GetItemsByBagAndSlot()) do
 			item:UpdateUpgrade(ectx)
+		end
+	end)
+
+	events:RegisterMessage("groups/Deleted", function(ectx, groupID, _, groupKind)
+		if groupKind == b.kind then
+			b:DeleteTabView(ectx, groupID)
 		end
 	end)
 	-- Setup the context menu.

--- a/frames/bag.lua
+++ b/frames/bag.lua
@@ -110,6 +110,12 @@ function bagFrame.bagProto:Show(ctx)
 		return
 	end
 	self.behavior:OnShow(ctx)
+	if self.drawPendingOnShow then
+		self.drawPendingOnShow = false
+		if self.lastSlotInfo then
+			self:Draw(ctx, self.lastSlotInfo, function() end)
+		end
+	end
 end
 
 ---@param ctx Context
@@ -238,6 +244,15 @@ end
 ---@param slotInfo SlotInfo
 ---@param callback fun()
 function bagFrame.bagProto:Draw(ctx, slotInfo, callback)
+	if not self:IsShown() then
+		self.lastSlotInfo = slotInfo
+		self.drawPendingOnShow = true
+		if callback then
+			callback()
+		end
+		return
+	end
+
 	local tabID = self:GetCurrentTabID()
 	local view = self:GetViewForTab(ctx, tabID)
 
@@ -248,6 +263,20 @@ function bagFrame.bagProto:Draw(ctx, slotInfo, callback)
 
 	if self.currentView and self.currentView ~= view then
 		self.currentView:GetContent():Hide()
+	end
+
+	-- Render other background persistent views first to keep them in a consistent data state
+	local currentLayout = database:GetBagView(self.kind)
+	if self.tabViews then
+		for viewKey, tView in pairs(self.tabViews) do
+			local layoutStr, tabIDStr = string.split("_", viewKey)
+			local layout = tonumber(layoutStr)
+			local tTabID = tonumber(tabIDStr)
+			if layout == currentLayout and tTabID ~= tabID then
+				tView:Render(ctx, self, slotInfo, function() end)
+				tView:GetContent():Hide()
+			end
+		end
 	end
 
 	debug:StartProfile("Bag Render %d", self.kind)

--- a/frames/classic/bag.lua
+++ b/frames/classic/bag.lua
@@ -119,10 +119,7 @@ function bagFrame:Create(ctx, kind)
   local animations = addon:GetModule('Animations')
   b.fadeInGroup, b.fadeOutGroup = animations:AttachFadeGroup(b.frame)
 
-  b.views = {
-    [const.BAG_VIEW.SECTION_GRID] = views:NewGrid(f, b.kind),
-    [const.BAG_VIEW.SECTION_ALL_BAGS] = views:NewBagView(f, b.kind),
-  }
+  b.tabViews = {}
 
   -- Register the bag frame so that window positions are saved.
   Window.RegisterConfig(b.frame, database:GetBagPosition(kind))

--- a/frames/classic/bag.lua
+++ b/frames/classic/bag.lua
@@ -19,9 +19,6 @@ local database = addon:GetModule('Database')
 ---@class ContextMenu: AceModule
 local contextMenu = addon:GetModule('ContextMenu')
 
----@class Views: AceModule
-local views = addon:GetModule('Views')
-
 ---@class Resize: AceModule
 local resize = addon:GetModule('Resize')
 

--- a/frames/era/bag.lua
+++ b/frames/era/bag.lua
@@ -118,10 +118,7 @@ function bagFrame:Create(ctx, kind)
   local animations = addon:GetModule('Animations')
   b.fadeInGroup, b.fadeOutGroup = animations:AttachFadeGroup(b.frame)
 
-  b.views = {
-    [const.BAG_VIEW.SECTION_GRID] = views:NewGrid(f, b.kind),
-    [const.BAG_VIEW.SECTION_ALL_BAGS] = views:NewBagView(f, b.kind),
-  }
+  b.tabViews = {}
 
   -- Register the bag frame so that window positions are saved.
   Window.RegisterConfig(b.frame, database:GetBagPosition(kind))

--- a/frames/era/bag.lua
+++ b/frames/era/bag.lua
@@ -19,9 +19,6 @@ local database = addon:GetModule('Database')
 ---@class ContextMenu: AceModule
 local contextMenu = addon:GetModule('ContextMenu')
 
----@class Views: AceModule
-local views = addon:GetModule('Views')
-
 ---@class Resize: AceModule
 local resize = addon:GetModule('Resize')
 

--- a/spec/views/persistent_tabs_spec.lua
+++ b/spec/views/persistent_tabs_spec.lua
@@ -20,8 +20,9 @@ debug.WalkAndFixAnchorGraph = function() end
 
 local database = StubBetterBagsModule("Database")
 database.GetBagSizeInfo = function()
-  return { itemsPerRow = 5, columnCount = 4 }
+  return { itemsPerRow = 5, columnCount = 4, scale = 100 }
 end
+database.GetGroup = function() return nil end
 database.GetBagView = function() return 1 end
 database.GetInBagSearch = function() return false end
 database.GetShowNewItemFlash = function() return false end
@@ -43,6 +44,8 @@ local const = StubBetterBagsModule("Constants")
 const.BAG_VIEW = { SECTION_GRID = 1, SECTION_ALL_BAGS = 2 }
 const.BAG_KIND = { UNDEFINED = -1, BACKPACK = 0, BANK = 1 }
 const.GRID_COMPACT_STYLE = { NONE = 0 }
+const.BANK_TAB = { BANK = -1, REAGENT = -2, ACCOUNT_BANK_1 = -3 }
+const.BANK_ONLY_BAGS = {}
 const.OFFSETS = {
   BAG_LEFT_INSET = 10,
   BAG_TOP_INSET = -40,
@@ -142,6 +145,10 @@ LoadBetterBagsModule("data/binding.lua")
 LoadBetterBagsModule("data/items.lua")
 
 local items = addon:GetModule("Items")
+items._firstLoad = {
+  [const.BAG_KIND.BACKPACK] = false,
+  [const.BAG_KIND.BANK] = false,
+}
 -- We can set up items.slotInfo map to use our mock
 items.slotInfo = {
   [const.BAG_KIND.BACKPACK] = {
@@ -187,6 +194,35 @@ local context = addon:GetModule("Context")
 describe("Persistent Tab Views and Zero-Guard State Consistency Tests", function()
   local old_strsplit = _G.strsplit
   local old_split = string.split
+
+  local function setupBagFrameStubs()
+    -- Register mock LibWindow-1.1 library
+    local libWindow = LibStub:NewLibrary("LibWindow-1.1", 1) or LibStub("LibWindow-1.1")
+    libWindow.RestorePosition = libWindow.RestorePosition or function() end
+    libWindow.RegisterConfig = libWindow.RegisterConfig or function() end
+
+    -- Stub remaining modules needed by frames/bag.lua
+    local contextMenu = StubBetterBagsModule("ContextMenu")
+    contextMenu.CreateContextMenu = function() return {} end
+
+    StubBetterBagsModule("BagSlots")
+    local resize = StubBetterBagsModule("Resize")
+    resize.MakeResizable = function() return { Hide = function() end } end
+
+    StubBetterBagsModule("Currency")
+    local searchBox = StubBetterBagsModule("SearchBox")
+    searchBox.GetText = function() return "" end
+
+    StubBetterBagsModule("ThemeConfig")
+    StubBetterBagsModule("WindowGroup")
+    local anchor = StubBetterBagsModule("Anchor")
+    anchor.New = function() return {} end
+
+    StubBetterBagsModule("Question")
+    StubBetterBagsModule("Search")
+    StubBetterBagsModule("BackpackBehavior")
+    StubBetterBagsModule("BankBehavior")
+  end
 
   before_each(function()
     _G.strsplit = function(sep, str, max)
@@ -292,32 +328,7 @@ describe("Persistent Tab Views and Zero-Guard State Consistency Tests", function
   end)
 
   it("should cleanly wipe and recycle views and buttons when a tab is deleted", function()
-    -- Register mock LibWindow-1.1 library
-    local libWindow = LibStub:NewLibrary("LibWindow-1.1", 1) or LibStub("LibWindow-1.1")
-    libWindow.RestorePosition = libWindow.RestorePosition or function() end
-    libWindow.RegisterConfig = libWindow.RegisterConfig or function() end
-
-    -- Stub remaining modules needed by frames/bag.lua
-    local contextMenu = StubBetterBagsModule("ContextMenu")
-    contextMenu.CreateContextMenu = function() return {} end
-
-    StubBetterBagsModule("BagSlots")
-    local resize = StubBetterBagsModule("Resize")
-    resize.MakeResizable = function() return { Hide = function() end } end
-
-    StubBetterBagsModule("Currency")
-    local searchBox = StubBetterBagsModule("SearchBox")
-    searchBox.GetText = function() return "" end
-
-    StubBetterBagsModule("ThemeConfig")
-    StubBetterBagsModule("WindowGroup")
-    local anchor = StubBetterBagsModule("Anchor")
-    anchor.New = function() return {} end
-
-    StubBetterBagsModule("Question")
-    StubBetterBagsModule("Search")
-    StubBetterBagsModule("BackpackBehavior")
-    StubBetterBagsModule("BankBehavior")
+    setupBagFrameStubs()
 
     -- Mock a bag portrait window frame and load BagFrame
     LoadBetterBagsModule("frames/bag.lua")
@@ -347,5 +358,167 @@ describe("Persistent Tab Views and Zero-Guard State Consistency Tests", function
     assert.is_true(wipeCalled)
     assert.is_true(contentWipeCalled)
     assert.is_nil(bag.tabViews[database:GetBagView(bag.kind) .. "_2"])
+  end)
+
+  it("should parent emptyGroupFrame to content container instead of bag frame and respect view.tabID", function()
+    local parent = CreateFrame("Frame")
+    -- We can set up grid with a container mock
+    local view = views:NewGrid(parent, const.BAG_KIND.BACKPACK, 1) -- Tab 1
+    assert.is_not_nil(view.emptyGroupFrame)
+    -- Verify parenting is view.content:GetContainer()
+    assert.equals(view.emptyGroupFrame:GetParent(), view.content:GetContainer())
+
+    -- Verify rendering tabID = 1 does NOT show emptyGroupFrame
+    local ctx = context:New("test")
+    local bag = { kind = const.BAG_KIND.BACKPACK, frame = CreateFrame("Frame") }
+    local mockSlotInfo = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return {} end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = { GetStackInfo = function() end },
+      totalItems = 0
+    }
+    view:Render(ctx, bag, mockSlotInfo, function() end)
+    assert.is_false(view.emptyGroupFrame:IsShown())
+
+    -- Now test custom tab ID > 1 (e.g., 2)
+    local view2 = views:NewGrid(parent, const.BAG_KIND.BACKPACK, 2) -- Tab 2
+    assert.is_not_nil(view2.emptyGroupFrame)
+    view2:Render(ctx, bag, mockSlotInfo, function() end)
+    -- Since totalItems is 0 and visible non-special section count is 0, emptyGroupFrame should show
+    assert.is_true(view2.emptyGroupFrame:IsShown())
+  end)
+
+  it("should render all instantiated views matching the current layout in bag:Draw()", function()
+    setupBagFrameStubs()
+    LoadBetterBagsModule("frames/bag.lua")
+    local frame = CreateFrame("Frame")
+    frame.SetScale = function() end
+    local bag = {
+      kind = const.BAG_KIND.BACKPACK,
+      frame = frame,
+      tabViews = {},
+      GetCurrentTabID = function() return 1 end,
+      IsShown = function() return true end,
+      OnResize = function() end,
+      behavior = {
+        OnShow = function() end,
+      }
+    }
+    setmetatable(bag, { __index = addon:GetModule("BagFrame").bagProto })
+
+    local ctx = context:New("test")
+    -- Create view for Tab 1 and Tab 2
+    local view1 = bag:GetViewForTab(ctx, 1)
+    local view2 = bag:GetViewForTab(ctx, 2)
+
+    local render1_called = false
+    local render2_called = false
+    view1.Render = function(self, ...) render1_called = true; select(4, ...)(...) end
+    view2.Render = function(self, ...) render2_called = true; select(4, ...)(...) end
+
+    local mockSlotInfo = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return {} end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = { GetStackInfo = function() end },
+      totalItems = 0
+    }
+
+    bag:Draw(ctx, mockSlotInfo, function() end)
+
+    -- Assert both views were rendered
+    assert.is_true(render1_called)
+    assert.is_true(render2_called)
+  end)
+
+  it("should skip rendering in Draw() when the bag is not shown, and draw when shown", function()
+    setupBagFrameStubs()
+    LoadBetterBagsModule("frames/bag.lua")
+    local frame = CreateFrame("Frame")
+    frame.SetScale = function() end
+    local shown = false
+    frame.IsShown = function() return shown end
+    local bag = {
+      kind = const.BAG_KIND.BACKPACK,
+      frame = frame,
+      tabViews = {},
+      GetCurrentTabID = function() return 1 end,
+      OnResize = function() end,
+      behavior = {
+        OnShow = function() shown = true end,
+      }
+    }
+    setmetatable(bag, { __index = addon:GetModule("BagFrame").bagProto })
+
+    local ctx = context:New("test")
+    local view = bag:GetViewForTab(ctx, 1)
+
+    local render_called = false
+    view.Render = function(self, ...) render_called = true; select(4, ...)(...) end
+
+    local mockSlotInfo = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return {} end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = { GetStackInfo = function() end },
+      totalItems = 0
+    }
+
+    -- Call Draw while hidden
+    bag:Draw(ctx, mockSlotInfo, function() end)
+    assert.is_false(render_called)
+    assert.is_true(bag.drawPendingOnShow)
+    assert.equals(bag.lastSlotInfo, mockSlotInfo)
+
+    -- Show the bag now
+    bag:Show(ctx)
+
+    -- Verify it rendered on show
+    assert.is_true(render_called)
+    assert.is_false(bag.drawPendingOnShow)
+  end)
+
+  it("should populate bagList with both BANK_BAGS and ACCOUNT_BANK_BAGS when GetShowBankTabs is true in Retail", function()
+    local old_isRetail = addon.isRetail
+    addon.isRetail = true
+    local old_GetShowBankTabs = database.GetShowBankTabs
+    database.GetShowBankTabs = function() return true end
+    equipmentSets.Update = function() end
+    addon.Bags = { Bank = {} }
+
+    -- Set up const values
+    const.ACCOUNT_BANK_BAGS = { [13] = 13, [14] = 14 }
+    const.BANK_BAGS = { [6] = 6, [7] = 7 }
+    const.BANK_ONLY_BAGS = {}
+
+    -- Mock LoadBagItems to observe bagList
+    local capturedBagList = nil
+    items.LoadBagItems = function(self, ctx, kind, bagList, save, callback)
+      capturedBagList = bagList
+      callback(ctx, {}, {})
+    end
+    items.LoadItems = function(self, ctx, kind, itemData, equipmentData, callback)
+      callback(ctx)
+    end
+
+    local ctx = context:New("test")
+    items:RefreshBank(ctx)
+
+    assert.is_not_nil(capturedBagList)
+    assert.is_not_nil(capturedBagList[6])
+    assert.is_not_nil(capturedBagList[7])
+    assert.is_not_nil(capturedBagList[13])
+    assert.is_not_nil(capturedBagList[14])
+
+    -- Clean up
+    addon.isRetail = old_isRetail
+    database.GetShowBankTabs = old_GetShowBankTabs
   end)
 end)

--- a/spec/views/persistent_tabs_spec.lua
+++ b/spec/views/persistent_tabs_spec.lua
@@ -1,0 +1,351 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("BetterBags")
+
+-- Load required modules
+LoadBetterBagsModule("core/context.lua")
+LoadBetterBagsModule("core/events.lua")
+LoadBetterBagsModule("core/pool.lua")
+
+local events = addon:GetModule("Events")
+events:OnInitialize()
+
+-- Stub modules before loading views and items
+local L = StubBetterBagsModule("Localization")
+L.G = function(self, key) return key end
+
+local debug = StubBetterBagsModule("Debug")
+debug.Log = function() end
+debug.StartProfile = function() end
+debug.EndProfile = function() end
+debug.WalkAndFixAnchorGraph = function() end
+
+local database = StubBetterBagsModule("Database")
+database.GetBagSizeInfo = function()
+  return { itemsPerRow = 5, columnCount = 4 }
+end
+database.GetBagView = function() return 1 end
+database.GetInBagSearch = function() return false end
+database.GetShowNewItemFlash = function() return false end
+database.GetGroupsEnabled = function() return true end
+database.GetActiveGroup = function() return 1 end
+database.GetShowBankTabs = function() return false end
+database.GetShowAllFreeSpace = function() return false end
+database.GetCategoryFilter = function() return nil end
+database.GetStackingOptions = function()
+  return {
+    mergeStacks = true,
+    unmergeAtShop = false,
+    dontMergePartial = false,
+    mergeUnstackable = false,
+  }
+end
+
+local const = StubBetterBagsModule("Constants")
+const.BAG_VIEW = { SECTION_GRID = 1, SECTION_ALL_BAGS = 2 }
+const.BAG_KIND = { UNDEFINED = -1, BACKPACK = 0, BANK = 1 }
+const.GRID_COMPACT_STYLE = { NONE = 0 }
+const.OFFSETS = {
+  BAG_LEFT_INSET = 10,
+  BAG_TOP_INSET = -40,
+  BAG_RIGHT_INSET = -10,
+  BAG_BOTTOM_INSET = 10,
+  BOTTOM_BAR_HEIGHT = 20,
+  BOTTOM_BAR_BOTTOM_INSET = 5,
+  SCROLLBAR_WIDTH = 12,
+}
+const.BACKPACK_BAGS = { [0] = true, [1] = true }
+const.BANK_BAGS = { [6] = 6, [7] = 7, [8] = 8, [9] = 9, [10] = 10, [11] = 11 }
+const.ACCOUNT_BANK_BAGS = {}
+
+local sort = StubBetterBagsModule("Sort")
+sort.SortSectionsAlphabetically = function() return true end
+sort.GetSectionSortFunction = function() return function() return true end end
+sort.GetItemSortFunction = function() return function() return true end end
+
+local themes = StubBetterBagsModule("Themes")
+themes.GetTabButton = function() return {} end
+themes.GetItemButton = function() return { UpgradeIcon = { SetShown = function() end } } end
+themes.RegisterPortraitWindow = function() end
+themes.SetSearchState = function() end
+
+local categories
+local ok = pcall(function() categories = addon:GetModule("Categories") end)
+if not ok or not categories then
+  categories = StubBetterBagsModule("Categories")
+end
+categories.IsCategoryShown = function() return true end
+categories.GetCategoryByName = function() return nil end
+categories.GetCategoryFilter = function() return nil end
+categories.CreateCategory = function() end
+
+local groups = StubBetterBagsModule("Groups")
+groups.CategoryBelongsToGroup = function() return true end
+
+-- Stub SectionFrame
+local sectionFrame = StubBetterBagsModule("SectionFrame")
+local sectionProto = {
+  ReleaseAllCells = function() end,
+  Release = function() end,
+  GetCellCount = function() return 1 end,
+  SetMaxCellWidth = function() end,
+  Draw = function() end,
+  SetTitle = function() end,
+  GetAllCells = function() return {} end,
+  AddCell = function() end,
+  RemoveCell = function() end,
+}
+sectionFrame.Create = function()
+  local s = setmetatable({}, { __index = sectionProto })
+  s.frame = CreateFrame("Frame")
+  return s
+end
+
+-- Mock Grid module
+local mockGridProto = {
+  HideScrollBar = function() end,
+  ShowScrollBar = function() end,
+  EnableMouseWheelScroll = function() end,
+  Wipe = function() end,
+  Sort = function() end,
+  SortVertical = function() end,
+  Draw = function(self, options) return 100, 50 end,
+  GetContainer = function(self)
+    if not self._container then self._container = CreateFrame("Frame") end
+    return self._container
+  end,
+  GetScrollView = function() return CreateFrame("Frame") end,
+  Show = function() end,
+  Hide = function() end,
+  AddCell = function() end,
+  RemoveCell = function() end,
+}
+local grid = StubBetterBagsModule("Grid")
+grid.Create = function()
+  local g = setmetatable({}, { __index = mockGridProto })
+  g.cells = {}
+  return g
+end
+
+-- Load items.lua (actual module) so we use the real GetBagKindFromSlotKey / GetItemDataFromSlotKey
+local equipmentSets = StubBetterBagsModule("EquipmentSets")
+equipmentSets.GetItemSets = function() return nil end
+
+local tooltipScanner = StubBetterBagsModule("TooltipScanner")
+tooltipScanner.GetTooltipText = function() return "" end
+
+LoadBetterBagsModule("util/query.lua")
+LoadBetterBagsModule("util/trees/trees.lua")
+LoadBetterBagsModule("util/trees/intervaltree.lua")
+LoadBetterBagsModule("data/search.lua")
+LoadBetterBagsModule("core/async.lua")
+LoadBetterBagsModule("data/stacks.lua")
+LoadBetterBagsModule("data/binding.lua")
+LoadBetterBagsModule("data/items.lua")
+
+local items = addon:GetModule("Items")
+-- We can set up items.slotInfo map to use our mock
+items.slotInfo = {
+  [const.BAG_KIND.BACKPACK] = {
+    itemsBySlotKey = {},
+  },
+  [const.BAG_KIND.BANK] = {
+    itemsBySlotKey = {},
+  },
+}
+
+-- Mock ItemFrame
+local itemFrame = StubBetterBagsModule("ItemFrame")
+itemFrame.Create = function()
+  local i = {
+    slotkey = nil,
+    SetItem = function(self, ctx, slotkey)
+      local data = items:GetItemDataFromSlotKey(slotkey)
+      if data == nil then
+        return
+      end
+      self.slotkey = slotkey
+    end,
+    GetItemData = function(self)
+      if self.staticData then return self.staticData end
+      return items:GetItemDataFromSlotKey(self.slotkey)
+    end,
+    UpdateUpgrade = function(self, ctx)
+      self:GetItemData()
+    end,
+  }
+  return i
+end
+
+-- Load views modules
+ResetModuleStub("Views", "views/views.lua")
+ResetModuleStub("GridViewDummy", "views/gridview.lua")
+LoadBetterBagsModule("views/views.lua")
+local views = addon:GetModule("Views")
+LoadBetterBagsModule("views/gridview.lua")
+
+local context = addon:GetModule("Context")
+
+describe("Persistent Tab Views and Zero-Guard State Consistency Tests", function()
+  local old_strsplit = _G.strsplit
+  local old_split = string.split
+
+  before_each(function()
+    _G.strsplit = function(sep, str, max)
+      if str == nil then
+        error("bad argument #2 to 'strsplit' (string expected, got nil)", 2)
+      end
+      return old_strsplit(sep, str, max)
+    end
+    string.split = function(sep, str, max)
+      if str == nil then
+        error("bad argument #2 to 'split' (string expected, got nil)", 2)
+      end
+      return old_strsplit(sep, str, max)
+    end
+  end)
+
+  after_each(function()
+    _G.strsplit = old_strsplit
+    string.split = old_split
+    items.slotInfo[const.BAG_KIND.BACKPACK].itemsBySlotKey = {}
+    items.slotInfo[const.BAG_KIND.BANK].itemsBySlotKey = {}
+    ResetModuleStub("ContextMenu")
+    ResetModuleStub("BagSlots")
+    ResetModuleStub("Resize")
+    ResetModuleStub("Currency")
+    ResetModuleStub("SearchBox")
+    ResetModuleStub("ThemeConfig")
+    ResetModuleStub("WindowGroup", "util/windowgroup.lua")
+    ResetModuleStub("Anchor")
+    ResetModuleStub("Question")
+    ResetModuleStub("Search")
+    ResetModuleStub("BackpackBehavior")
+    ResetModuleStub("BankBehavior")
+    ResetModuleStub("BagFrame", "frames/bag.lua")
+  end)
+
+  it("should reproduce the nil slotkey crash when items data is transient/nil during UpdateButton", function()
+    -- Set up an empty slotInfo with slotkeys but NO actual item data in the slotInfo database
+    local parent = CreateFrame("Frame")
+    local view = views:NewGrid(parent, const.BAG_KIND.BANK)
+
+    -- Define a slot key for which we have NO item data (transient loading state)
+    local testSlotKey = "6_1"
+
+    local testItemData = {
+      slotkey = testSlotKey,
+      bagid = 6,
+      slotid = 1,
+      itemHash = "hash1",
+      isItemEmpty = false,
+      itemInfo = {
+        currentItemCount = 20,
+        itemStackCount = 20,
+      }
+    }
+
+    -- Define a mock slotInfo where stackInfo claims rootItem is testSlotKey
+    local mockStackInfo = {
+      rootItem = testSlotKey,
+      slotkeys = { [testSlotKey] = true },
+      itemHash = "hash1",
+    }
+
+    local mockSlotInfo = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return { [testSlotKey] = testItemData } end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = {
+        GetStackInfo = function(self, hash)
+          return mockStackInfo
+        end
+      },
+      totalItems = 1
+    }
+
+    -- Verify that calling GridView (view.Render) triggers ReconcileStack.
+    -- Because items:GetItemDataFromSlotKey(testSlotKey) is nil (stale/loading),
+    -- CreateButton returns false, prompting UpdateButton to run.
+    -- UpdateButton allocates an itemButton with view:GetOrCreateItemButton(ctx, testSlotKey),
+    -- and then calls itemButton:SetItem(ctx, testSlotKey).
+    -- itemButton:SetItem sees the item data is nil and returns early, leaving itemButton.slotkey as nil.
+    -- The button remains registered in view.itemsByBagAndSlot[testSlotKey] = itemButton.
+    local ctx = context:New("test")
+    ctx:Set("redraw", true)
+    local bag = { kind = const.BAG_KIND.BANK, frame = CreateFrame("Frame") }
+    view:Render(ctx, bag, mockSlotInfo, function() end)
+
+    -- Assert that under the new refactored state-consistent logic,
+    -- no ghost button is created when item data is nil.
+    local itemButton = view:GetItemsByBagAndSlot()[testSlotKey]
+    assert.is_nil(itemButton)
+
+    -- Assert that calling UpdateUpgrade on all mapped view items is completely
+    -- safe and does not crash because no ghost buttons exist.
+    for _, item in pairs(view:GetItemsByBagAndSlot()) do
+      local success = pcall(function()
+        item:UpdateUpgrade(context:New("test"))
+      end)
+      assert.is_true(success)
+    end
+  end)
+
+  it("should cleanly wipe and recycle views and buttons when a tab is deleted", function()
+    -- Register mock LibWindow-1.1 library
+    local libWindow = LibStub:NewLibrary("LibWindow-1.1", 1) or LibStub("LibWindow-1.1")
+    libWindow.RestorePosition = libWindow.RestorePosition or function() end
+    libWindow.RegisterConfig = libWindow.RegisterConfig or function() end
+
+    -- Stub remaining modules needed by frames/bag.lua
+    local contextMenu = StubBetterBagsModule("ContextMenu")
+    contextMenu.CreateContextMenu = function() return {} end
+
+    StubBetterBagsModule("BagSlots")
+    local resize = StubBetterBagsModule("Resize")
+    resize.MakeResizable = function() return { Hide = function() end } end
+
+    StubBetterBagsModule("Currency")
+    local searchBox = StubBetterBagsModule("SearchBox")
+    searchBox.GetText = function() return "" end
+
+    StubBetterBagsModule("ThemeConfig")
+    StubBetterBagsModule("WindowGroup")
+    local anchor = StubBetterBagsModule("Anchor")
+    anchor.New = function() return {} end
+
+    StubBetterBagsModule("Question")
+    StubBetterBagsModule("Search")
+    StubBetterBagsModule("BackpackBehavior")
+    StubBetterBagsModule("BankBehavior")
+
+    -- Mock a bag portrait window frame and load BagFrame
+    LoadBetterBagsModule("frames/bag.lua")
+    local bag = {
+      kind = const.BAG_KIND.BACKPACK,
+      frame = CreateFrame("Frame"),
+      tabViews = {}
+    }
+    setmetatable(bag, { __index = addon:GetModule("BagFrame").bagProto })
+
+    local ctx = context:New("test")
+    -- Create view for Tab 2
+    local view2 = bag:GetViewForTab(ctx, 2)
+    assert.is_not_nil(view2)
+    assert.is_not_nil(bag.tabViews[database:GetBagView(bag.kind) .. "_2"])
+
+    -- Stub view:Wipe and view:GetContent():Wipe
+    local wipeCalled = false
+    local contentWipeCalled = false
+    view2.WipeHandler = function() wipeCalled = true end
+    view2:GetContent().Wipe = function() contentWipeCalled = true end
+
+    -- Delete tab/view 2
+    bag:DeleteTabView(ctx, 2)
+
+    -- Assert that clean wipe was performed and reference was removed
+    assert.is_true(wipeCalled)
+    assert.is_true(contentWipeCalled)
+    assert.is_nil(bag.tabViews[database:GetBagView(bag.kind) .. "_2"])
+  end)
+end)

--- a/views/bagview.lua
+++ b/views/bagview.lua
@@ -21,6 +21,12 @@ local itemFrame = addon:GetModule('ItemFrame')
 ---@class Database: AceModule
 local database = addon:GetModule('Database')
 
+---@class Items: AceModule
+local items = addon:GetModule('Items')
+
+---@class Groups: AceModule
+local groups = addon:GetModule('Groups')
+
 ---@class Sort: AceModule
 local sort = addon:GetModule('Sort')
 
@@ -96,6 +102,10 @@ end
 ---@param view View
 ---@param slotkey string
 local function UpdateButton(ctx, view, slotkey)
+  local item = items:GetItemDataFromSlotKey(slotkey)
+  if not item then
+    return
+  end
   view:RemoveDeferredItem(slotkey)
   local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
   itemButton:SetItem(ctx, slotkey)
@@ -122,6 +132,62 @@ local function UpdateViewSize(view)
   end
 end
 
+local function ItemBelongsToTab(view, bagKind, item)
+  if not item then return false end
+  if bagKind == const.BAG_KIND.BANK and database:GetShowBankTabs() then
+    return item.bagid == view.tabID
+  end
+  if database:GetGroupsEnabled(bagKind) then
+    local category = items:GetCategory(nil, item)
+    local isSpecialSection = category == L:G("Free Space") or category == L:G("Recent Items")
+    if isSpecialSection then
+      return true -- Special sections are shown on all tabs
+    end
+    return groups:CategoryBelongsToGroup(bagKind, category, view.tabID)
+  end
+  return true
+end
+
+local function FilterChangesetForTab(view, bagKind, added, removed, changed)
+  local tabAdded, tabRemoved, tabChanged = {}, {}, {}
+
+  -- 1. If an item was added globally, and belongs to our tab: add it.
+  for _, item in pairs(added) do
+    if ItemBelongsToTab(view, bagKind, item) then
+      table.insert(tabAdded, item)
+    end
+  end
+
+  -- 2. If an item was removed globally:
+  -- We can't always check ItemBelongsToTab on the current state if its category or bag changed.
+  -- But we can check if we currently have a button frame for this slotkey!
+  -- If we have a button frame for this slotkey, and it was removed globally: we must remove it from our tab!
+  for _, item in pairs(removed) do
+    if view.itemsByBagAndSlot[item.slotkey] then
+      table.insert(tabRemoved, item)
+    end
+  end
+
+  -- 3. If an item was changed globally:
+  for _, item in pairs(changed) do
+    local belongsNow = ItemBelongsToTab(view, bagKind, item)
+    local hadButton = (view.itemsByBagAndSlot[item.slotkey] ~= nil)
+
+    if belongsNow and not hadButton then
+      -- It now belongs to us, but we didn't have it before: treat as added!
+      table.insert(tabAdded, item)
+    elseif not belongsNow and hadButton then
+      -- It no longer belongs to us, but we had it before: treat as removed!
+      table.insert(tabRemoved, item)
+    elseif belongsNow and hadButton then
+      -- It belongs to us, and we had it before: keep as changed!
+      table.insert(tabChanged, item)
+    end
+  end
+
+  return tabAdded, tabRemoved, tabChanged
+end
+
 ---@param view View
 ---@param ctx Context
 ---@param bag Bag
@@ -135,6 +201,8 @@ local function BagView(view, ctx, bag, slotInfo, callback)
   local sizeInfo = database:GetBagSizeInfo(bag.kind, const.BAG_VIEW.SECTION_ALL_BAGS)
 
   local added, removed, changed = slotInfo:GetChangeset()
+
+  added, removed, changed = FilterChangesetForTab(view, bag.kind, added, removed, changed)
 
   for _, item in pairs(removed) do
     ClearButton(ctx, view, item)
@@ -240,13 +308,15 @@ end
 
 ---@param parent Frame
 ---@param kind BagKind
+---@param tabID? number
 ---@return View
-function views:NewBagView(parent, kind)
+function views:NewBagView(parent, kind, tabID)
   local view = views:NewBlankView()
   view.itemFrames = {}
   view.itemCount = 0
   view.bagview = const.BAG_VIEW.SECTION_ALL_BAGS
   view.kind = kind
+  view.tabID = tabID or 1
   view.content = grid:Create(parent)
   view.content:GetContainer():ClearAllPoints()
   view.content:GetContainer():SetPoint("TOPLEFT", parent, "TOPLEFT", const.OFFSETS.BAG_LEFT_INSET, const.OFFSETS.BAG_TOP_INSET)

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -439,7 +439,7 @@ local function GridView(view, ctx, bag, slotInfo, callback)
   -- Also filter by active group (if groups are enabled).
   local activeGroup = nil
   if database:GetGroupsEnabled(bag.kind) and not (bag.kind == const.BAG_KIND.BANK and database:GetShowBankTabs()) then
-    activeGroup = database:GetActiveGroup(bag.kind)
+    activeGroup = view.tabID
   end
 
   for sectionName, section in pairs(view:GetAllSections()) do
@@ -711,10 +711,9 @@ function views:NewGrid(parent, kind, tabID)
 
   -- Create empty group state frame (only for backpack)
   if kind == const.BAG_KIND.BACKPACK then
-    local emptyGroupFrame = CreateFrame("Frame", nil, parent)
-    emptyGroupFrame:SetPoint("TOPLEFT", parent, "TOPLEFT", const.OFFSETS.BAG_LEFT_INSET, const.OFFSETS.BAG_TOP_INSET)
-    emptyGroupFrame:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", const.OFFSETS.BAG_RIGHT_INSET, const.OFFSETS.BAG_BOTTOM_INSET + const.OFFSETS.BOTTOM_BAR_BOTTOM_INSET + 20)
-    emptyGroupFrame:SetFrameLevel(parent:GetFrameLevel() + 10)
+    local emptyGroupFrame = CreateFrame("Frame", nil, view.content:GetContainer())
+    emptyGroupFrame:SetAllPoints()
+    emptyGroupFrame:SetFrameLevel(view.content:GetContainer():GetFrameLevel() + 10)
     emptyGroupFrame:Hide()
 
     local helpText = emptyGroupFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -129,6 +129,10 @@ end
 ---@param view View
 ---@param slotkey string
 local function UpdateButton(ctx, view, slotkey)
+  local item = items:GetItemDataFromSlotKey(slotkey)
+  if not item then
+    return
+  end
   debug:Log("UpdateButton", "Updating button for item", slotkey)
   local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
   itemButton:SetItem(ctx, slotkey)
@@ -226,11 +230,68 @@ local function ReconcileStack(ctx, view, stackInfo)
     end
   end
 
-  -- The root item is always drawn, so first, let's draw it.
-  if not CreateButton(ctx, view, stackInfo.rootItem) then
-   -- And update it just in case it aleady exists.
-   UpdateButton(ctx, view, stackInfo.rootItem)
+  -- The root item is always drawn, so let's draw or update it.
+  if view.itemsByBagAndSlot[stackInfo.rootItem] then
+    UpdateButton(ctx, view, stackInfo.rootItem)
+  else
+    CreateButton(ctx, view, stackInfo.rootItem)
   end
+end
+
+local function ItemBelongsToTab(view, bagKind, item)
+  if not item then return false end
+  if bagKind == const.BAG_KIND.BANK and database:GetShowBankTabs() then
+    return item.bagid == view.tabID
+  end
+  if database:GetGroupsEnabled(bagKind) then
+    local category = items:GetCategory(nil, item)
+    local isSpecialSection = category == L:G("Free Space") or category == L:G("Recent Items")
+    if isSpecialSection then
+      return true -- Special sections are shown on all tabs
+    end
+    return groups:CategoryBelongsToGroup(bagKind, category, view.tabID)
+  end
+  return true
+end
+
+local function FilterChangesetForTab(view, bagKind, added, removed, changed)
+  local tabAdded, tabRemoved, tabChanged = {}, {}, {}
+
+  -- 1. If an item was added globally, and belongs to our tab: add it.
+  for _, item in pairs(added) do
+    if ItemBelongsToTab(view, bagKind, item) then
+      table.insert(tabAdded, item)
+    end
+  end
+
+  -- 2. If an item was removed globally:
+  -- We can't always check ItemBelongsToTab on the current state if its category or bag changed.
+  -- But we can check if we currently have a button frame for this slotkey!
+  -- If we have a button frame for this slotkey, and it was removed globally: we must remove it from our tab!
+  for _, item in pairs(removed) do
+    if view.itemsByBagAndSlot[item.slotkey] then
+      table.insert(tabRemoved, item)
+    end
+  end
+
+  -- 3. If an item was changed globally:
+  for _, item in pairs(changed) do
+    local belongsNow = ItemBelongsToTab(view, bagKind, item)
+    local hadButton = (view.itemsByBagAndSlot[item.slotkey] ~= nil)
+
+    if belongsNow and not hadButton then
+      -- It now belongs to us, but we didn't have it before: treat as added!
+      table.insert(tabAdded, item)
+    elseif not belongsNow and hadButton then
+      -- It no longer belongs to us, but we had it before: treat as removed!
+      table.insert(tabRemoved, item)
+    elseif belongsNow and hadButton then
+      -- It belongs to us, and we had it before: keep as changed!
+      table.insert(tabChanged, item)
+    end
+  end
+
+  return tabAdded, tabRemoved, tabChanged
 end
 
 ---@param view View
@@ -259,6 +320,8 @@ local function GridView(view, ctx, bag, slotInfo, callback)
   elseif ctx:GetBool('wipe') then
     view:Wipe(ctx)
   end
+
+  added, removed, changed = FilterChangesetForTab(view, bag.kind, added, removed, changed)
 
   local opts = database:GetStackingOptions(bag.kind)
 
@@ -627,12 +690,14 @@ end
 
 ---@param parent Frame
 ---@param kind BagKind
+---@param tabID? number
 ---@return View
-function views:NewGrid(parent, kind)
+function views:NewGrid(parent, kind, tabID)
   local view = views:NewBlankView()
   view.itemCount = 0
   view.bagview = const.BAG_VIEW.SECTION_GRID
   view.kind = kind
+  view.tabID = tabID or 1
   view.content = grid:Create(parent)
   view.content:SortVertical()
   view.content:GetContainer():ClearAllPoints()


### PR DESCRIPTION
### Summary of Changes

* **Backpack Help Text Fix:** Reparented the `emptyGroupFrame` to the view content container so it is properly hidden when the inactive view content is hidden. Changed visibility checks to use `view.tabID` instead of the global `activeGroup` to avoid background-rendering other tab views polluting the main Backpack tab's visibility logic.
* **Empty Custom/Backpack Tabs Fix:** Modified `Draw()` in `frames/bag.lua` to render and reconcile all instantiated persistent views for the active layout simultaneously. Hidden tab views no longer miss transient item changesets (`added`, `removed`, `changed`).
* **Bank Tab Content Mismatch Fix:** When `database:GetShowBankTabs()` is active in Retail, `RefreshBank` now loads both Character bank bags (`const.BANK_BAGS`) and Account/Warband bank bags (`const.ACCOUNT_BANK_BAGS`) simultaneously, allowing persistent views to correctly filter and display their items dynamically.
* **Closed-bag CPU Gating:** Added checks to skip rendering (`Draw()`) when a bag is closed (`self:IsShown() == false`), caching `slotInfo` and setting `drawPendingOnShow`. Reopening the bag triggers a deferred draw with the cached data.

### Motivation

During the transition to the new persistent tab views architecture ("one view per tab"), several issues arose:
1. The "Drag a section header to this tab" help text appeared when it shouldn't, especially on the main Backpack tab, due to incorrect frame parenting and global state checking.
2. Custom tabs and background backpack tabs were found to be empty because transient item changesets were only being processed by the globally active view, so background views missed the data entirely.
3. When using Blizzard "Show Bags", bank tabs had mismatched contents because `RefreshBank` was filtering the source items too aggressively before giving them to the tabs.
4. With multiple persistent views updating on events, we needed a safeguard to prevent CPU-intensive layout calculations when the player's bags are closed.

### Testing & Validation

* Wrote 4 targeted integration tests under `spec/views/persistent_tabs_spec.lua` to simulate and cover:
  * Backpack help text parenting and visibility isolation.
  * Correct propagation of changesets to all rendered views in `bag:Draw()`.
  * Proper loading and scanning of both character and account bank bags in Retail mode.
  * Early exit / CPU gating correctness when the bag is hidden.
* Executed full Busted test suite with 871 total successes addon-wide.
* Ran `luacheck` against modified files (`frames/bag.lua`, `views/gridview.lua`, `data/items.lua`, `spec/views/persistent_tabs_spec.lua`) and confirmed 0 warnings / 0 errors.