### PR TITLE
fix: preserve static item button slotkey identities

### DIFF
--- a/frames/era/item.lua
+++ b/frames/era/item.lua
@@ -252,7 +252,6 @@ function itemFrame.itemProto:ClearItem(ctx)
   self.freeSlotName = ""
   self.freeSlotCount = 0
   self.isFreeSlot = nil
-  self.slotkey = ""
   self.staticData = nil
   self:UpdateCooldown(ctx)
 end

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -705,7 +705,6 @@ function itemFrame.itemProto:ClearItem(ctx)
 	self.ilvlText:SetText("")
 	self.ilvlText:Hide()
 	self:ResetSize(ctx)
-	self.slotkey = ""
 	self.stacks = {}
 	self.stackCount = 1
 	self.stackid = nil

--- a/spec/frames/item_spec.lua
+++ b/spec/frames/item_spec.lua
@@ -45,6 +45,7 @@ local themes = StubBetterBagsModule("Themes")
 themes.GetItemButton = function(_, buttonCtx, item)
   if not item._decoration then
     item._decoration = {
+      SetSize = function() end,
       SetID = function(_, id) item._decoration.id = id end,
       SetMatchesSearch = function() end,
       ItemSlotBackground = { Hide = function() end, Show = function() end },
@@ -251,5 +252,13 @@ describe("ItemFrame Static Buttons and Parent Removal Tests", function()
     -- Assert that UpdateExtended was called on both
     assert.equal(1, buttonUpdateExtendedCalled, "button:UpdateExtended was not called on SetFreeSlots")
     assert.equal(1, decUpdateExtendedCalled, "decoration:UpdateExtended was not called on SetFreeSlots")
+  end)
+
+  it("should preserve the slotkey when Wipe or ClearItem is called", function()
+    local btnCtx = ctx:New("test_wipe_preserves_slotkey")
+    local item = itemFrame:GetButton(btnCtx, "0_5")
+    assert.equal("0_5", item.slotkey)
+    item:Wipe(btnCtx)
+    assert.equal("0_5", item.slotkey)
   end)
 end)


### PR DESCRIPTION
### Summary
Fixes a bug where item buttons would disappear when switching between bank and warbank views or sorting the bank. The root cause was that `ClearItem()` was incorrectly stripping the `slotkey` identity from the static item buttons. In the new static button system, physical item buttons are permanently bound to their respective bag/slot identities and are no longer pooled/recycled.

### Motivation
When rendering or wiping background views, `ClearItem()` erased the `slotkey` identity of the static buttons. This caused them to become functionally disconnected and disappear from the UI when views refreshed (e.g., swapping to the warbank and back, or sorting the bank). By preserving the `slotkey`, buttons remain intact and properly bound to their static `bag:slot` combinations at all times.

### Testing and Validation
- **Unit Testing**: Added a new TDD test in `spec/frames/item_spec.lua` to ensure that both `Wipe` and `ClearItem` preserve the `slotkey` identity of the item buttons.
- **Suite Pass**: Successfully verified that all 881 tests pass under the strict Lua 5.1 environment (`./lua51-rocks/bin/busted`).
- **Code Linter**: `luacheck` run across the modified files (`frames/item.lua`, `frames/era/item.lua`, `spec/frames/item_spec.lua`) reported 0 warnings and 0 errors.
- **Mock Update**: Added the missing `SetSize` method to the theme item decoration mock in the test suite to accurately reflect WoW UI behavior.