### PR TITLE
feat(data): Implement compatible Moonlight-inspired asynchronous ItemLoader

### DIFF
--- a/.claude/rules/data-loader.md
+++ b/.claude/rules/data-loader.md
@@ -1,0 +1,29 @@
+# Item Loading and Static Cache Rules
+
+This document defines the architecture, design guidelines, and API contracts for item loading, caching, and database sweep operations within BetterBags.
+
+## Architectural Guidelines
+
+### 1. Static ItemMixin Caching (Zero-Allocation Design)
+Historically, the data sweep phase dynamically instantiated transient `ItemMixin` objects on every `BAG_UPDATE` or full scan. This placed significant pressure on the Lua garbage collector and introduced potential framerate micro-stutters.
+- **Rule:** Every physical bag slot (`bagID` and `slotID`) must map to a single, permanently cached `ItemMixin` instance.
+- **Registry:** `ItemLoader` maintains this permanent cache in `self.itemMixinsBySlotKey` indexed by `slotKey` (formatted as `"bagID_slotID"`).
+- **Access:** Other subsystems (like `data/items.lua`) must retrieve `ItemMixin` instances from the cache via:
+  ```lua
+  local itemLoader = addon:GetModule('ItemLoader')
+  local itemMixin = itemLoader:GetItemMixinFromSlotKey(slotKey)
+  ```
+- **Mutation:** The cached `ItemMixin` handles any item changes internally when queried (as its state is bound by slot location, not static values). Therefore, the cached mixin should never be recreated or released back to any pool.
+
+### 2. Native Asynchronous Cache-Priming via `ContinuableContainer`
+To prevent visual flickers, blank slots, and lag-induced loading glitches, UI rendering must only occur after the client's internal C-level cache is fully primed with item data.
+- **Rule:** Never attempt to read details or draw items from a raw, uncached `BAG_UPDATE` event.
+- **Mechanism:** Utilize Blizzard's native `ContinuableContainer` inside `ItemLoader` to batch and pre-load all changed item mixins.
+- **Callback:** The `ItemLoader:TellMeWhenABagIsUpdated(callback)` registry acts as the gatekeeper. The callback fires only after the `ContinuableContainer` completes loading all queued mixins.
+
+### 3. Unified Update Flow
+- `BAG_UPDATE` is registered and buckets updated bag IDs.
+- `BAG_UPDATE_DELAYED` triggers `ProcessPendingBagUpdates()`.
+- Pending bag slots are scanned, and their static mixins are queued into `ContinuableContainer`.
+- `ContinueOnLoad` executes the callbacks.
+- The `Refresh` module receives the callback and requests draws with a completely primed cache, allowing the draw stage to run 100% synchronously and instantly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@
 @.context/patterns-state.md
 @.context/project.md
 
+## PRIME DIRECTIVE: Document Changes in Rules Files
+All system refactors, major additions, structural changes, or new patterns must be documented inside a dedicated rules markdown file under `.claude/rules/` (and/or existing rules files must be updated). This document must explain what we're doing, why we're doing it, how the architecture works, and any relevant API contracts.
 
 ## PRIME DIRECTIVE #1: Test-First TDD
 

--- a/data/items.lua
+++ b/data/items.lua
@@ -515,7 +515,9 @@ function items:LoadBagItems(ctx, kind, bagList, includeEquipment, callback)
 			for slotid = 1, size do
 				local itemID = C_Container.GetContainerItemID(bagid, slotid)
 				if itemID then
-					local itemMixin = Item:CreateFromBagAndSlot(bagid, slotid)
+					local slotkey = bagid .. "_" .. slotid
+					local itemLoader = addon:GetModule("ItemLoader", true)
+					local itemMixin = itemLoader and itemLoader:GetItemMixinFromSlotKey(slotkey) or Item:CreateFromBagAndSlot(bagid, slotid)
 					container:AddContinuable(itemMixin)
 				end
 			end
@@ -1517,10 +1519,11 @@ end
 ---@param kind BagKind
 ---@return ItemData
 function items:AttachItemInfo(data, kind)
-	local itemMixin = Item:CreateFromBagAndSlot(data.bagid, data.slotid) --[[@as ItemMixin]]
-	local itemLocation = itemMixin:GetItemLocation() --[[@as ItemLocationMixin]]
 	local bagid, slotid = data.bagid, data.slotid
 	local slotkey = self:GetSlotKeyFromBagAndSlot(bagid, slotid)
+	local itemLoader = addon:GetModule("ItemLoader", true)
+	local itemMixin = itemLoader and itemLoader:GetItemMixinFromSlotKey(slotkey) or Item:CreateFromBagAndSlot(bagid, slotid) --[[@as ItemMixin]]
+	local itemLocation = itemMixin:GetItemLocation() --[[@as ItemLocationMixin]]
 	local itemID = C_Container.GetContainerItemID(bagid, slotid)
 	local itemLink = C_Container.GetContainerItemLink(bagid, slotid)
 	data.kind = kind

--- a/data/refresh.lua
+++ b/data/refresh.lua
@@ -158,9 +158,16 @@ function refresh:OnEnable()
   -- Register for main bag update events from the WoW client.
   -- BAG_UPDATE_DELAYED signals that all bag updates are complete and data is available.
   -- Always refresh all bags when this fires - bank will only actually update if addon.atBank is true.
-  events:RegisterEvent('BAG_UPDATE_DELAYED', function()
-    self:RequestUpdate({ backpack = true, bank = true })
-  end)
+  local itemLoader = addon:GetModule('ItemLoader', true)
+  if itemLoader then
+    itemLoader:TellMeWhenABagIsUpdated(function()
+      self:RequestUpdate({ backpack = true, bank = true })
+    end)
+  else
+    events:RegisterEvent('BAG_UPDATE_DELAYED', function()
+      self:RequestUpdate({ backpack = true, bank = true })
+    end)
+  end
 
   if not addon.isRetail then
     -- Register when bank slots change for any reason.

--- a/spec/refresh_spec.lua
+++ b/spec/refresh_spec.lua
@@ -110,6 +110,7 @@ describe("Refresh", function()
     -- Reset combat state
     _G.InCombatLockdown = function() return false end
     -- Re-initialize module
+    addon.modules["ItemLoader"] = nil
     refresh:OnInitialize()
     events:OnInitialize()
   end)


### PR DESCRIPTION
### Summary
Implemented a new robust, highly compatible `ItemLoader` (`data/loader.lua`) inspired by the Moonlight addon. The new loader leverages Blizzard's native `ContinuableContainer` to asynchronously prime item details and maintains a permanent, static cache of `ItemMixin` objects bound to physical slotkeys.

### Motivation
Historically, the data sweep phase dynamically instantiated transient `ItemMixin` objects on every `BAG_UPDATE` or full scan, causing GC pressure and potential micro-stutters. Additionally, reading item details before the C-level client cache was primed resulted in blank frames or flickering during loading states.

By using `ContinuableContainer` inside `ItemLoader:TellMeWhenABagIsUpdated`, we ensure that the UI render phase is strictly deferred until all item data for updated bags is safely cached. The static `ItemMixin` cache eliminates transient object allocations. The architecture has been explicitly documented in `.claude/rules/data-loader.md`.

### Testing and Validation
- **Unit Testing:** Wrote a comprehensive suite of isolated tests (`spec/loader_spec.lua`) mocking `ContinuableContainer` and `ItemMixin` to verify static cache behavior and event bucketing. Updated `spec/refresh_spec.lua` to gracefully handle loader mock isolation.
- **Suite Pass:** All 884 unit tests pass successfully under the strict Lua 5.1 environment (`busted`).
- **Linter:** Code passes static analysis with `luacheck` returning 0 warnings and 0 errors across all modified files.