### PR TITLE
Fix bank tab item disappearances and unassigned category leakage

### DIFF
--- a/.claude/rules/data-loader.md
+++ b/.claude/rules/data-loader.md
@@ -27,3 +27,9 @@ To prevent visual flickers, blank slots, and lag-induced loading glitches, UI re
 - Pending bag slots are scanned, and their static mixins are queued into `ContinuableContainer`.
 - `ContinueOnLoad` executes the callbacks.
 - The `Refresh` module receives the callback and requests draws with a completely primed cache, allowing the draw stage to run 100% synchronously and instantly.
+
+### 4. Unified Retail Bank Loading and Persistent Tab Filtering
+To support instant, synchronous tab switching with zero visual flickers or loading stutters:
+- **Unified Cache:** On Retail, the data-loading pipeline (`data/items.lua`) always loads all bank bags (both Character Bank and Account/Warbank bags) into a single, unified `slotInfo` cache, regardless of the active tab.
+- **Strict Filtering:** Both `gridview.lua` and `bagview.lua` strictly partition this complete cache via `ItemBelongsToTab()`. Items in `ACCOUNT_BANK_BAGS` only render in Account/Warbank tabs, while items in `BANK_BAGS` only render in Character Bank tabs, preventing unassigned category leakage between tabs.
+- **Instant Swapping:** Since the cache is always complete, tab switching (`SwitchToGroup` or `SwitchToBlizzardTab`) does not wipe caches or trigger server-refresh messages. Instead, the UI simply hides the old view, fetches the new view, and calls `Draw()` synchronously and instantly.

--- a/bags/bank.lua
+++ b/bags/bank.lua
@@ -252,9 +252,9 @@ function bank.proto:SwitchToBlizzardTab(ctx, bagIndex)
 	end
 
 	self.bag.currentItemCount = -1
-	items:ClearBankCache(ctx)
 	ctx:Set("redraw", true)
-	events:SendMessage(ctx, "bags/RefreshBank")
+	local slotInfo = items:GetAllSlotInfo()[const.BAG_KIND.BANK]
+	self.bag:Draw(ctx, slotInfo, function() end)
 	ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
 end
 
@@ -565,10 +565,9 @@ function bank.proto:SwitchToGroup(ctx, groupID)
 	self.bag:SetTitle(group.name)
 	self.bag.currentItemCount = -1
 
-	items:ClearBankCache(ctx)
 	ctx:Set("redraw", true)
-
-	events:SendMessage(ctx, "bags/RefreshBank")
+	local slotInfo = items:GetAllSlotInfo()[const.BAG_KIND.BANK]
+	self.bag:Draw(ctx, slotInfo, function() end)
 	ItemButtonUtil.TriggerEvent(ItemButtonUtil.Event.ItemContextChanged)
 end
 

--- a/data/items.lua
+++ b/data/items.lua
@@ -590,7 +590,7 @@ function items:RefreshBags(ctx, kind)
 		-- If the bank slots panel has selected a specific Blizzard tab, only
 		-- load items from that single bag index instead of all bank bags.
 		local blizzardTab = addon.Bags.Bank and addon.Bags.Bank.blizzardBankTab
-		if database:GetShowBankTabs() and addon.isRetail then
+		if addon.isRetail then
 			-- When bank tabs setting is enabled in Retail, we load ALL bank bags (both Character and Account)
 			-- so that persistent tab-scoped views can filter and display them correctly.
 			ctx:Set("bagid", const.BANK_TAB.BANK)

--- a/spec/frames/bankslots_spec.lua
+++ b/spec/frames/bankslots_spec.lua
@@ -40,6 +40,19 @@ const.OFFSETS = {
 
 local items = StubBetterBagsModule("Items")
 items.ClearBankCache = function() end
+items.GetAllSlotInfo = function()
+  return {
+    [const.BAG_KIND.BANK] = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return {} end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = { GetStackInfo = function() end },
+      totalItems = 0
+    }
+  }
+end
 
 StubBetterBagsModule("Tabs")
 StubBetterBagsModule("Groups")
@@ -283,6 +296,7 @@ describe("Bank Bag/Slot Window Pane Tests", function()
         },
         slots = panel,
         Wipe = function() end,
+        Draw = function() end,
         blizzardBankTab = 10,
       }
 

--- a/spec/views/persistent_tabs_spec.lua
+++ b/spec/views/persistent_tabs_spec.lua
@@ -82,6 +82,13 @@ categories.CreateCategory = function() end
 
 local groups = StubBetterBagsModule("Groups")
 groups.CategoryBelongsToGroup = function() return true end
+groups.GetGroup = function(self, kind, id)
+  return database:GetGroup(kind, id)
+end
+groups.IsDefaultGroup = function(self, kind, id)
+  local group = database:GetGroup(kind, id)
+  return group and group.isDefault == true
+end
 
 -- Stub SectionFrame
 local sectionFrame = StubBetterBagsModule("SectionFrame")
@@ -120,6 +127,7 @@ local mockGridProto = {
   Hide = function() end,
   AddCell = function() end,
   RemoveCell = function() end,
+  GetCell = function() return nil end,
 }
 local grid = StubBetterBagsModule("Grid")
 grid.Create = function()
@@ -600,5 +608,132 @@ describe("Persistent Tab Views and Zero-Guard State Consistency Tests", function
     assert.is_true(callbackCalled)
     assert.is_false(view.isNew)
     assert.is_not_nil(view.itemsByBagAndSlot["0_1"])
+  end)
+
+  it("should always load both BANK_BAGS and ACCOUNT_BANK_BAGS in Retail regardless of GetShowBankTabs", function()
+    local old_isRetail = addon.isRetail
+    addon.isRetail = true
+    local old_GetShowBankTabs = database.GetShowBankTabs
+    database.GetShowBankTabs = function() return false end
+    equipmentSets.Update = function() end
+    addon.Bags = { Bank = {} }
+
+    -- Set up const values
+    const.ACCOUNT_BANK_BAGS = { [13] = 13, [14] = 14 }
+    const.BANK_BAGS = { [6] = 6, [7] = 7 }
+    const.BANK_ONLY_BAGS = {}
+
+    -- Mock LoadBagItems to observe bagList
+    local capturedBagList = nil
+    items.LoadBagItems = function(self, ctx, kind, bagList, save, callback)
+      capturedBagList = bagList
+      callback(ctx, {}, {})
+    end
+    items.LoadItems = function(self, ctx, kind, itemData, equipmentData, callback)
+      callback(ctx)
+    end
+
+    local ctx = context:New("test")
+    items:RefreshBank(ctx)
+
+    assert.is_not_nil(capturedBagList)
+    assert.is_not_nil(capturedBagList[6])
+    assert.is_not_nil(capturedBagList[7])
+    assert.is_not_nil(capturedBagList[13])
+    assert.is_not_nil(capturedBagList[14])
+
+    -- Clean up
+    addon.isRetail = old_isRetail
+    database.GetShowBankTabs = old_GetShowBankTabs
+  end)
+
+  it("should filter bank items strictly by tab bankType in Retail when ShowBankTabs is false", function()
+    local old_isRetail = addon.isRetail
+    addon.isRetail = true
+    local old_Enum = _G.Enum
+    _G.Enum = _G.Enum or {}
+    _G.Enum.BankType = { Character = 1, Account = 2 }
+
+    local old_GetShowBankTabs = database.GetShowBankTabs
+    database.GetShowBankTabs = function() return false end
+
+    -- Mock database GetGroup to return character bank for Tab 1, account bank for Tab 2
+    local old_GetGroup = database.GetGroup
+    database.GetGroup = function(_, kind, id)
+      if id == 1 then
+        return { id = 1, isDefault = true, bankType = _G.Enum.BankType.Character }
+      elseif id == 2 then
+        return { id = 2, isDefault = true, bankType = _G.Enum.BankType.Account }
+      end
+      return nil
+    end
+
+    local old_CategoryBelongsToGroup = groups.CategoryBelongsToGroup
+    groups.CategoryBelongsToGroup = function() return true end
+
+    local old_IsDefaultGroup = groups.IsDefaultGroup
+    groups.IsDefaultGroup = function() return true end
+
+    -- Set up bag constants
+    const.BANK_BAGS = { [6] = 6 }
+    const.ACCOUNT_BANK_BAGS = { [13] = 13 }
+
+    -- Create mock items
+    local charItem = {
+      slotkey = "6_1",
+      bagid = 6,
+      slotid = 1,
+      itemHash = "hash_6_1",
+      isItemEmpty = false,
+      itemInfo = { currentItemCount = 1, itemStackCount = 20, isItemEmpty = false, category = "TestCategory" }
+    }
+    local warItem = {
+      slotkey = "13_1",
+      bagid = 13,
+      slotid = 1,
+      itemHash = "hash_13_1",
+      isItemEmpty = false,
+      itemInfo = { currentItemCount = 1, itemStackCount = 20, isItemEmpty = false, category = "TestCategory" }
+    }
+
+    items.slotInfo[const.BAG_KIND.BANK].itemsBySlotKey["6_1"] = charItem
+    items.slotInfo[const.BAG_KIND.BANK].itemsBySlotKey["13_1"] = warItem
+
+    local mockSlotInfo = {
+      GetChangeset = function() return {}, {}, {} end,
+      GetCurrentItems = function() return { ["6_1"] = charItem, ["13_1"] = warItem } end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      stacks = { GetStackInfo = function() end },
+      totalItems = 2
+    }
+
+    local parent = CreateFrame("Frame")
+    local bag = { kind = const.BAG_KIND.BANK, frame = CreateFrame("Frame") }
+
+    -- Tab 1 (Character Bank)
+    local view1 = views:NewGrid(parent, const.BAG_KIND.BANK, 1)
+    view1:Render(context:New("test"), bag, mockSlotInfo, function() end)
+
+    -- Assert only charItem is drawn in view1
+    assert.is_not_nil(view1.itemsByBagAndSlot["6_1"])
+    assert.is_nil(view1.itemsByBagAndSlot["13_1"])
+
+    -- Tab 2 (Account Bank)
+    local view2 = views:NewGrid(parent, const.BAG_KIND.BANK, 2)
+    view2:Render(context:New("test"), bag, mockSlotInfo, function() end)
+
+    -- Assert only warItem is drawn in view2
+    assert.is_nil(view2.itemsByBagAndSlot["6_1"])
+    assert.is_not_nil(view2.itemsByBagAndSlot["13_1"])
+
+    -- Clean up
+    addon.isRetail = old_isRetail
+    _G.Enum = old_Enum
+    database.GetShowBankTabs = old_GetShowBankTabs
+    database.GetGroup = old_GetGroup
+    groups.CategoryBelongsToGroup = old_CategoryBelongsToGroup
+    groups.IsDefaultGroup = old_IsDefaultGroup
   end)
 end)

--- a/views/bagview.lua
+++ b/views/bagview.lua
@@ -131,8 +131,18 @@ end
 
 local function ItemBelongsToTab(view, bagKind, item)
   if not item then return false end
-  if bagKind == const.BAG_KIND.BANK and database:GetShowBankTabs() then
-    return item.bagid == view.tabID
+  if bagKind == const.BAG_KIND.BANK then
+    if database:GetShowBankTabs() then
+      return item.bagid == view.tabID
+    end
+    local activeGroup = groups:GetGroup(const.BAG_KIND.BANK, view.tabID)
+    if activeGroup and addon.isRetail then
+      local itemIsAccountBank = (const.ACCOUNT_BANK_BAGS[item.bagid] ~= nil)
+      local tabIsAccountBank = (Enum.BankType and activeGroup.bankType == Enum.BankType.Account)
+      if itemIsAccountBank ~= tabIsAccountBank then
+        return false
+      end
+    end
   end
   if database:GetGroupsEnabled(bagKind) then
     local category = items:GetCategory(nil, item)

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -240,8 +240,18 @@ end
 
 local function ItemBelongsToTab(view, bagKind, item)
   if not item then return false end
-  if bagKind == const.BAG_KIND.BANK and database:GetShowBankTabs() then
-    return item.bagid == view.tabID
+  if bagKind == const.BAG_KIND.BANK then
+    if database:GetShowBankTabs() then
+      return item.bagid == view.tabID
+    end
+    local activeGroup = groups:GetGroup(const.BAG_KIND.BANK, view.tabID)
+    if activeGroup and addon.isRetail then
+      local itemIsAccountBank = (const.ACCOUNT_BANK_BAGS[item.bagid] ~= nil)
+      local tabIsAccountBank = (Enum.BankType and activeGroup.bankType == Enum.BankType.Account)
+      if itemIsAccountBank ~= tabIsAccountBank then
+        return false
+      end
+    end
   end
   if database:GetGroupsEnabled(bagKind) then
     local category = items:GetCategory(nil, item)


### PR DESCRIPTION
## Summary of Changes
This PR completely resolves the bank tab disappearing items and unassigned category leakage bugs by migrating the bank tab architecture to a **Pure Static Persistent View** model.

1. **Unified Retail Bank Loading**:
   - Modified `items:RefreshBags` on Retail to **always load both Character Bank and Account Bank bags** into the unified `slotInfo` cache, regardless of the active tab.

2. **Strict Physical Bag Tab Filtering**:
   - Updated `ItemBelongsToTab()` in both grid and bag views. When rendering group-based bank tabs on Retail, it strictly matches the group's `bankType` (Character vs Account/Warbank) with the physical item's `bagid`. This cleanly partitions the unified cache and prevents unassigned category items from leaking across tabs.

3. **Instant, Synchronous Tab Swapping**:
   - Removed synchronous cache clearing and delayed refresh events in `SwitchToGroup` and `SwitchToBlizzardTab`.
   - The UI now simply fetches the complete `slotInfo` and draws it immediately, allowing instant, zero-flicker swaps.

4. **Updated Rule Documentation**:
   - Added architectural guidelines to `.claude/rules/data-loader.md` detailing the unified loading, persistent filtering, and instant tab swapping.

## Motivation
Previously, switching bank tabs conditionally loaded subset bags and discarded context, causing incomplete view caches. This led to missing buttons when swapping tabs and unassigned items showing up in both tabs since both are considered default groups. Switching to a pure static persistent view model ensures the item cache is always full, and views simply filter and show/hide what they are responsible for.

## Testing and Validation Performed
- All 886 / 886 tests pass successfully with zero errors or failures.
- Added tests in `spec/views/persistent_tabs_spec.lua` and `spec/frames/bankslots_spec.lua` to verify the unified bag loading and strict filtering logic.
- `luacheck` output is clean with 0 warnings/errors.
- Verified in the Lua 5.1 runtime environment as per project requirements.