### PR TITLE
feat(bank): implement flat headerless section for Blizzard Bags view

### DIFF
--- a/.claude/rules/data-loader.md
+++ b/.claude/rules/data-loader.md
@@ -76,3 +76,9 @@ To permanently prevent ObjectPool contamination, cell leakage, and fatal `Cannot
 - **Rule:** Every rendering pass for a view is functionally isolated and begins with a complete, synchronous wipe of its own frames, returning all of its pooled elements back to the global stacks before any rendering/population occurs.
 - **Mechanism:** The very first line of each view's `Render` method (e.g. `GridView` or `BagView`) executes `view:Wipe(ctx)`.
 - **State Transition (`isNew` flag):** Inside `Wipe(view, ctx)`, explicitly set `view.isNew = true` to flag the view as completely empty. At the beginning of the `Render` method (right after wiping), set `view.isNew = false` to indicate the view is populated and complete. This guarantees 100% clean-slate rendering on every single frame update.
+
+### 10. Flat "Blizzard Bags" View for Bank (Single Headerless Section)
+To support a flat view of the Bank bags resembling physical containers while maintaining visual alignment:
+- **Rule:** When the bank view is set to `SECTION_ALL_BAGS` (Blizzard Bags view), we bypass physical-bag individual sections. Instead, all physical bank slots (both items and empty slots) are consolidated into a single section named `"Bank"`.
+- **Headerless Layout:** The section uses `section:RemoveHeader()`, which hides its title text and anchors the grid content directly to the top left of the section frame, eliminating redundant title heights.
+- **Strict Physical Sorting:** To preserve the real locations and blank spaces of physical bags, this single consolidated section is rendered with `freeSpaceShown = true`, which enforces sorting by exact physical slot key (`sort.GetItemSortBySlot`).

--- a/ask/plans/start/plan.md
+++ b/ask/plans/start/plan.md
@@ -1,56 +1,24 @@
-# Implementation Plan
+# Implementation Plan: Flat "Blizzard Bags" View for Bank
 
-This plan details the exact steps to fix the three post-architecture-refactor bugs relating to scrolling, Warbank free space counts, and Blizzard Bank tabs rendering. 
+## 1. Add `RemoveHeader` support to Sections (`frames/section.lua`)
+- Add a new method `sectionProto:RemoveHeader()` which sets a flag (e.g. `self.removeHeader = true`).
+- In `sectionProto:Grid(kind, view, freeSpaceShown, nosort)`, check for this flag:
+  - If `self.removeHeader` is true, do not add `self.title:GetHeight() + 6` to the `fullHeight`.
+  - Instead of anchoring the content grid to `self.title` `"BOTTOMLEFT"`, anchor it directly to `self.frame` `"TOPLEFT"`.
+  - Call `self.title:Hide()`.
+  - For normal (header-enabled) sections, ensure `self.title:Show()` is called and the normal anchoring and height logic is used.
+- In `sectionProto:Wipe()` and `sectionFrame._DoReset(ctx, f)`, reset `self.removeHeader = false` to ensure properly recycled sections for the pool.
 
-## 1. Bug 1: Scroll clipping off-screen
+## 2. Consolidate into a Single Section for Bank (`views/bagview_new.lua`)
+- In `BagView(view, ctx, bag, slotInfo, callback)` where it iterates over `currentItems`:
+  - If `view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS` and `bag.kind == const.BAG_KIND.BANK`:
+    - Hardcode the category to a single shared string (e.g., `L:G("Items")` or `"Everything"`), so all items group together in one section.
+- Also, in the empty slots iteration (`view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS`), apply the same bypass for `bag.kind == const.BAG_KIND.BANK` so empty slots merge into the same single category as the items.
 
-**Root Cause:**
-Blizzard's `WowScrollBox` with a `LinearView` checks for children with `scrollable = true` during its initialization phase to calculate the pan extent. Currently, `scrollChild.scrollable = true` is set *after* `ScrollUtil.InitScrollBoxWithScrollBar` is invoked, meaning the box initializes with an assumed scroll range of 0.
+## 3. Configure Headerless Layout and Sorting (`views/bagview_new.lua`)
+- In the active sections drawing loop `for _, section in pairs(view:GetAllSections()) do`:
+  - If `view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS` and `bag.kind == const.BAG_KIND.BANK`, call `section:RemoveHeader()`.
+  - We need to sort by physical slot. `sectionProto:Grid` uses `sort.GetItemSortBySlot` when `freeSpaceShown = true`. Currently `section:Draw(...)` is passed `false` as the third parameter. We will modify this call to pass `true` as the third parameter (`freeSpaceShown`) if it's the `SECTION_ALL_BAGS` bank view, which effectively applies `GetItemSortBySlot` for this specific view mode.
 
-**Implementation Steps:**
-- **File:** `frames/bag.lua`
-- **Location:** `bagFrame.bagProto:Create` (around lines 777-780).
-- **Action:** Move the `scrollChild.scrollable = true` and `scrollChild:SetParent(scrollBox)` assignments to be physically located *before* the `ScrollUtil.InitScrollBoxWithScrollBar(scrollBox, scrollBar, scrollView)` call.
-
-## 2. Bug 2: Warbank free space shows total Bank free space
-
-**Root Cause:**
-Currently, `items:UpdateFreeSlots` aggregates the `emptySlots` counts strictly by the Blizzard subclass string (e.g., `"Bag"`). Since both Character Bank bags and Warbank bags share the `"Bag"` subclass string, their counts are unconditionally merged. When the UI renders the global footer, it displays the combined integer across all tabs.
-
-**Implementation Steps:**
-- **File:** `data/slots.lua`
-  - In `SlotInfo:Wipe` and `SlotInfo:Update`, reset `self.freeSlotKeysByBag = {}`.
-  - In `SlotInfo:StoreIfEmptySlot`, safely populate `self.freeSlotKeysByBag = self.freeSlotKeysByBag or {}` and `self.freeSlotKeysByBag[item.bagid] = item.slotkey`.
-- **File:** `data/items_new.lua` and `data/items.lua`
-  - In `UpdateFreeSlots`, preserve the existing `emptySlots` behavior but also populate a new mapping: `self.slotInfo[kind].emptySlotsByBag = self.slotInfo[kind].emptySlotsByBag or {}` and `self.slotInfo[kind].emptySlotsByBag[bagid] = { name = name, count = freeSlots }`.
-- **File:** `frames/bag.lua`
-  - Import the Groups module at the top: `local groups = addon:GetModule("Groups")`.
-  - In `bagProto:DrawGlobalSections`, introduce a helper function `IncludeBagInFreeSpace(bagid)` that checks if a `bagid` belongs to `self:GetCurrentTabID()` (using similar retail/account bank boolean logic as `ItemBelongsToTab`).
-  - Update the `database:GetShowAllFreeSpace` `true` path to skip items in `slotInfo.emptySlotsSorted` where `IncludeBagInFreeSpace(item.bagid)` is false.
-  - Update the `false` path to iterate over `slotInfo.emptySlotsByBag`, filtering via `IncludeBagInFreeSpace`, and dynamically aggregating the `freeSlotCount` sum per `name` to render the correct contextual counts on-the-fly.
-
-## 3. Bug 3: Blizzard Bank Tabs are totally busted (Rendering multiple tabs at once)
-
-**Root Cause:**
-In PR 1024, the cache was updated to always contain ALL bank items (Character + Warbank) simultaneously to allow instant tab-swapping. However, `ItemBelongsToTab` still features a legacy catch-all `if view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS then return true end` block. When switching to a specific Warbank tab in Blizzard Bag View, this causes the grid to render the Character bank, Warbank tab 1, Warbank tab 2, etc., all on top of each other.
-
-**Implementation Steps:**
-- **Files:** `views/gridview_new.lua` and `views/bagview_new.lua`
-- **Location:** `ItemBelongsToTab` function.
-- **Action:** Update the `SECTION_ALL_BAGS` escape block to restrict retail bank items mathematically to the viewed bank type.
-  ```lua
-  if view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS then
-    if bagKind == const.BAG_KIND.BANK and addon.isRetail then
-      if view.tabID == const.BANK_TAB.BANK then
-         -- Character Bank: Show everything that isn't Account Bank
-         return const.ACCOUNT_BANK_BAGS == nil or const.ACCOUNT_BANK_BAGS[item.bagid] == nil
-      else
-         -- Warbank Tabs: Only show the exact bag representing that specific tab
-         return item.bagid == view.tabID
-      end
-    end
-    return true
-  end
-  ```
-
-This exact sequence will be implemented and validated across all views natively.
+## 4. Verify Global Sections Hidden (`frames/bag.lua`)
+- No changes required. Code review of `bagFrame.bagProto:DrawGlobalSections` confirms that generation of "Recent Items" and "Free Space" is bypassed entirely (`if currentView ~= const.BAG_VIEW.SECTION_ALL_BAGS then ... end`). Since the bank uses the identical shared UI container frame logic, toggling to `SECTION_ALL_BAGS` will naturally skip evaluating and generating the global sections.

--- a/frames/section.lua
+++ b/frames/section.lua
@@ -194,6 +194,7 @@ function sectionProto:Wipe()
   self.frame:SetAlpha(1)
   self.collapsed = false
   self.shouldShrinkWhenCollapsed = true
+  self.removeHeader = false
   -- Clear originalTextColor - SetTitle will set the correct color when the section is reused.
   -- Note: We don't restore the color here because SetTitle always explicitly sets it,
   -- ensuring pooled sections don't bleed custom colors to other categories.
@@ -215,6 +216,10 @@ end
 
 function sectionProto:EnableHeader()
   self.headerDisabled = false
+end
+
+function sectionProto:RemoveHeader()
+  self.removeHeader = true
 end
 
 ---@param item Item|ItemRow
@@ -292,9 +297,19 @@ function sectionProto:Grid(kind, view, freeSpaceShown, nosort)
   end
 
   local fullWidth = w + 12
-  local fullHeight = h + self.title:GetHeight() + 6
+  local fullHeight = h
+  if not self.removeHeader then
+    fullHeight = fullHeight + self.title:GetHeight() + 6
+  end
 
-  self.content:GetContainer():SetPoint("TOPLEFT", self.title, "BOTTOMLEFT", 0, 0)
+  self.content:GetContainer():ClearAllPoints()
+  if self.removeHeader then
+    self.title:Hide()
+    self.content:GetContainer():SetPoint("TOPLEFT", self.frame, "TOPLEFT", 6, 0)
+  else
+    self.title:Show()
+    self.content:GetContainer():SetPoint("TOPLEFT", self.title, "BOTTOMLEFT", 0, 0)
+  end
   self.content:GetContainer():SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT", -6, 0)
 
   -- If collapsed, hide content and optionally shrink frame
@@ -312,7 +327,7 @@ function sectionProto:Grid(kind, view, freeSpaceShown, nosort)
     end
     -- Only shrink if we're allowed to (no other expanded sections in our row)
     if self.shouldShrinkWhenCollapsed then
-      local collapsedHeight = self.title:GetHeight() + 6
+      local collapsedHeight = self.removeHeader and 0 or (self.title:GetHeight() + 6)
       self.frame:SetSize(fullWidth, collapsedHeight)
     else
       -- Keep full height but hide content
@@ -333,7 +348,7 @@ function sectionProto:Grid(kind, view, freeSpaceShown, nosort)
   end
 
   self.frame:Show()
-  return fullWidth, (self.collapsed and self.shouldShrinkWhenCollapsed) and (self.title:GetHeight() + 6) or fullHeight
+  return fullWidth, (self.collapsed and self.shouldShrinkWhenCollapsed) and (self.removeHeader and 0 or (self.title:GetHeight() + 6)) or fullHeight
 end
 
 -------

--- a/spec/views/gridview_new_spec.lua
+++ b/spec/views/gridview_new_spec.lua
@@ -92,12 +92,28 @@ local sectionProto = {
   Draw = function() end,
   SetTitle = function() end,
   GetAllCells = function() return {} end,
-  AddCell = function() end,
+  AddCell = function(self, id, cell)
+    self.content:AddCell(id, cell)
+  end,
   WipeOnlyContents = function() end,
+  RemoveHeader = function(self) self.removeHeader = true end,
 }
 sectionFrame.Create = function()
   local s = setmetatable({}, { __index = sectionProto })
   s.frame = CreateFrame("Frame")
+  s.content = {
+    cells = {},
+    idToCell = {},
+    AddCell = function(self, id, cell)
+      self.idToCell[id] = cell
+      table.insert(self.cells, cell)
+    end,
+    GetCell = function(self, id)
+      return self.idToCell[id]
+    end,
+    Sort = function() end,
+    Draw = function() end,
+  }
   return s
 end
 
@@ -463,8 +479,9 @@ describe("Phase 6 View Placement and Rendering Tests", function()
 
     assert.is_true(rendered)
     -- Under character bank tabID = -1, ONLY character bank section should be rendered!
-    assert.is_not_nil(view.sections["#1: Bank"])
-    assert.is_nil(view.sections["#9: Warbank Tab 1"])
+    assert.is_not_nil(view.sections["Bank"])
+    assert.is_not_nil(view.sections["Bank"].content:GetCell("-1_1"))
+    assert.is_nil(view.sections["Bank"].content:GetCell("13_1"))
 
     -- Now let's switch tabID to 13 (Warbank Tab 1) and render again
     local view2 = views:NewBagView(parent, const.BAG_KIND.BANK)
@@ -476,12 +493,64 @@ describe("Phase 6 View Placement and Rendering Tests", function()
 
     assert.is_true(rendered)
     -- Under Warbank tabID = 13, ONLY warbank tab 13 should be rendered!
-    assert.is_nil(view2.sections["#1: Bank"])
-    assert.is_not_nil(view2.sections["#9: Warbank Tab 1"])
+    assert.is_not_nil(view2.sections["Bank"])
+    assert.is_nil(view2.sections["Bank"].content:GetCell("-1_1"))
+    assert.is_not_nil(view2.sections["Bank"].content:GetCell("13_1"))
 
     -- Reset to clean up state
     addon.isRetail = nil
     const.ACCOUNT_BANK_BAGS = nil
     const.BANK_TAB = nil
+  end)
+
+  it("should render bank items in a single, headerless, physical-slot sorted section in SECTION_ALL_BAGS view", function()
+    local parent = CreateFrame("Frame")
+    local view = views:NewBagView(parent, const.BAG_KIND.BANK)
+    local bag = { kind = const.BAG_KIND.BANK, frame = CreateFrame("Frame") }
+
+    items.GetItemDataFromSlotKey = function(self, slotkey)
+      return { slotkey = slotkey }
+    end
+
+    local itemCharacter1 = {
+      bagid = -1,
+      slotid = 1,
+      slotkey = "-1_1",
+      isItemEmpty = false,
+      itemInfo = { category = "Default", itemID = 11 },
+    }
+    local itemCharacter2 = {
+      bagid = -1,
+      slotid = 2,
+      slotkey = "-1_2",
+      isItemEmpty = false,
+      itemInfo = { category = "Default", itemID = 12 },
+    }
+
+    local mockSlotInfo = {
+      GetChangeset = function() return { itemCharacter1, itemCharacter2 }, {}, {} end,
+      GetCurrentItems = function() return { ["-1_1"] = itemCharacter1, ["-1_2"] = itemCharacter2 } end,
+      emptySlots = {},
+      freeSlotKeys = {},
+      emptySlotsSorted = {},
+      emptySlotByBagAndSlot = {},
+      stacks = {
+        GetStackInfo = function() return nil end
+      }
+    }
+
+    local rendered = false
+    view:Render(context:New("test"), bag, mockSlotInfo, function()
+      rendered = true
+    end)
+
+    assert.is_true(rendered)
+    -- There should be a section for "Bank" and NO sections for individual bag names like "#1: Bank"
+    assert.is_not_nil(view.sections["Bank"])
+    assert.is_nil(view.sections["#1: Bank"])
+
+    -- The section "Bank" should have been marked as headerless/removeHeader
+    local bankSection = view.sections["Bank"]
+    assert.is_true(bankSection.removeHeader)
   end)
 end)

--- a/spec/views/persistent_tabs_spec.lua
+++ b/spec/views/persistent_tabs_spec.lua
@@ -102,6 +102,7 @@ local sectionProto = {
   GetAllCells = function() return {} end,
   AddCell = function() end,
   RemoveCell = function() end,
+  RemoveHeader = function(self) self.removeHeader = true end,
 }
 sectionFrame.Create = function()
   local s = setmetatable({}, { __index = sectionProto })

--- a/views/bagview_new.lua
+++ b/views/bagview_new.lua
@@ -155,7 +155,11 @@ local function BagView(view, ctx, bag, slotInfo, callback)
       if view.bagview == const.BAG_VIEW.SECTION_GRID then
         category = item.itemInfo and item.itemInfo.category or L:G("Everything")
       elseif view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS then
-        category = GetBagName(item.bagid)
+        if bag.kind == const.BAG_KIND.BANK then
+          category = L:G("Bank")
+        else
+          category = GetBagName(item.bagid)
+        end
       end
 
       local section = view:GetOrCreateSection(ctx, category)
@@ -172,13 +176,22 @@ local function BagView(view, ctx, bag, slotInfo, callback)
 
   if view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS then
     for bagid, emptyBagData in pairs(slotInfo.emptySlotByBagAndSlot) do
-      for slotid, data in pairs(emptyBagData) do
-        local slotkey = view:GetSlotKey(data)
-        if C_Container.GetBagName(bagid) ~= nil then
-          local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
-          itemButton:SetFreeSlots(ctx, bagid, slotid, -1)
-          local section = view:GetOrCreateSection(ctx, GetBagName(bagid))
-          section:AddCell(slotkey, itemButton)
+      local dummyItem = { bagid = bagid }
+      if ItemBelongsToTab(view, bag.kind, dummyItem) then
+        for slotid, data in pairs(emptyBagData) do
+          local slotkey = view:GetSlotKey(data)
+          if C_Container.GetBagName(bagid) ~= nil then
+            local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
+            itemButton:SetFreeSlots(ctx, bagid, slotid, -1)
+            local category
+            if bag.kind == const.BAG_KIND.BANK then
+              category = L:G("Bank")
+            else
+              category = GetBagName(bagid)
+            end
+            local section = view:GetOrCreateSection(ctx, category)
+            section:AddCell(slotkey, itemButton)
+          end
         end
       end
     end
@@ -187,7 +200,12 @@ local function BagView(view, ctx, bag, slotInfo, callback)
   -- Draw active sections
   for _, section in pairs(view:GetAllSections()) do
     section:SetMaxCellWidth(sizeInfo.itemsPerRow)
-    section:Draw(bag.kind, database:GetBagView(bag.kind), false)
+    if view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS and bag.kind == const.BAG_KIND.BANK then
+      section:RemoveHeader()
+      section:Draw(bag.kind, database:GetBagView(bag.kind), true)
+    else
+      section:Draw(bag.kind, database:GetBagView(bag.kind), false)
+    end
   end
 
   -- Hide filtered sections
@@ -298,7 +316,8 @@ local function BagView(view, ctx, bag, slotInfo, callback)
 
   if needsRedraw then
     for _, section in ipairs(view.content.cells) do
-      section:Draw(bag.kind, database:GetBagView(bag.kind), false)
+      local freeSpaceShown = (view.bagview == const.BAG_VIEW.SECTION_ALL_BAGS and bag.kind == const.BAG_KIND.BANK)
+      section:Draw(bag.kind, database:GetBagView(bag.kind), freeSpaceShown)
     end
     view.content:Draw({
       cells = view.content.cells,


### PR DESCRIPTION
### Summary
This pull request implements a flat, headerless grid for the "Blizzard Bags" view (`SECTION_ALL_BAGS`) of the Bank. It introduces `sectionProto:RemoveHeader()` to support headerless sections, bypasses category categorization for bank tabs to consolidate physical bank bags and empty slots under a single `"Bank"` category, and enforces strict physical-slot sorting via `freeSpaceShown = true`.

### Motivation
The Bank window previously categorized physical bags differently from the Backpack in the `SECTION_ALL_BAGS` view. This change ensures the Bank provides a true native flat container view mirroring physical slots natively without redundant headers or sorting, matching the behavior that users expect when opting out of categorized grid views.

### Testing/Validation
- Added unit tests validating that the `SECTION_ALL_BAGS` view correctly intercepts bank elements and bundles them into a single, headerless section.
- Validated correct tracking of cells and `RemoveHeader` requests in the mock stubs.
- Ensured strict physical slot sorting (`freeSpaceShown = true`) is maintained for the consolidated view.
- 794 tests pass with 0 failures/errors.
- Passed `luacheck .` with zero errors or warnings.