### PR TITLE
fix: implement GetItemData API in Phase 4.5 pipeline

### DIFF
--- a/data/items_new.lua
+++ b/data/items_new.lua
@@ -837,7 +837,21 @@ function items:GetGroupBySuffix(data, groupBy)
 end
 
 function items:GetItemData(ctx, itemList, callback)
-  if callback then callback() end
+  local container = ContinuableContainer:Create()
+  for _, itemID in pairs(itemList) do
+    local itemMixin = Item:CreateFromItemID(itemID)
+    container:AddContinuable(itemMixin)
+  end
+  container:ContinueOnLoad(function()
+    ---@type ItemData[]
+    local dataList = {}
+    for _, itemID in pairs(itemList) do
+      local data = {} ---@type ItemData
+      self:AttachBasicItemInfo(itemID, data)
+      table.insert(dataList, data)
+    end
+    if callback then callback(ctx, dataList) end
+  end)
 end
 
 function items:IsNewItem(data)

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -772,6 +772,16 @@ _G.Item.CreateFromItemLocation = function(_, itemLocation)
   function item:IsItemEmpty() return false end
   return item
 end
+_G.Item.CreateFromItemID = function(_, itemID)
+  local item = {
+    _itemID = itemID,
+  }
+  function item:GetItemID() return self._itemID end
+  function item:IsItemEmpty() return false end
+  function item:IsItemDataLoaded() return true end
+  function item:ContinueOnItemLoad(callback) callback() end
+  return item
+end
 
 -- ContinuableContainer Setup
 _G.ContinuableContainer = _G.ContinuableContainer or {}

--- a/spec/items_new_spec.lua
+++ b/spec/items_new_spec.lua
@@ -737,4 +737,31 @@ describe("Items (New Data Farming Engine)", function()
       _G.C_Item.GetItemInfo = savedGetItemInfo
     end)
   end)
+
+  describe("GetItemData API", function()
+    it("should retrieve formatted item data asynchronously using ContinuableContainer", function()
+      local savedGetItemInfo = _G.C_Item.GetItemInfo
+      _G.C_Item.GetItemInfo = function(itemID)
+        return "Test Item " .. itemID, "|cff0070dd|Hitem:"..itemID.."|h[Test Item "..itemID.."]|h|r", 3, 100, 1, "Weapon", "One-Handed Swords", 1, "INVTYPE_WEAPON", 134400, 100, 2, 0, 1, 0, 0, false
+      end
+
+      local ctx = addon:GetModule("Context"):New("TestGetItemData")
+      local callbackCtx, callbackData
+      items:GetItemData(ctx, { 12345, 67890 }, function(ectx, dataList)
+        callbackCtx = ectx
+        callbackData = dataList
+      end)
+
+      assert.is_not_nil(callbackCtx)
+      assert.are.equal(ctx, callbackCtx)
+      assert.is_not_nil(callbackData)
+      assert.are.equal(2, #callbackData)
+      assert.are.equal(12345, callbackData[1].itemInfo.itemID)
+      assert.are.equal("Test Item 12345", callbackData[1].itemInfo.itemName)
+      assert.are.equal(67890, callbackData[2].itemInfo.itemID)
+      assert.are.equal("Test Item 67890", callbackData[2].itemInfo.itemName)
+
+      _G.C_Item.GetItemInfo = savedGetItemInfo
+    end)
+  end)
 end)


### PR DESCRIPTION
### Summary
Un-stubbed the `GetItemData` function in the Phase 4.5 pipeline (`data/items_new.lua`).

### Motivation
When the codebase transitioned to the new Phase 1-5 orchestrated data pipeline, the `GetItemData` function was stubbed out. This caused a nil-indexing crash in configuration panes (specifically Custom Categories) because they relied on this function to fetch item data for rendering icons. Un-stubbing and implementing this function via `ContinuableContainer` resolves the crash.

### Testing/Validation
- Implemented `items:GetItemData` using `ContinuableContainer` and `AttachBasicItemInfo`.
- Mocked `_G.Item.CreateFromItemID` to ensure comprehensive testability.
- Wrote a targeted unit test (`spec/items_new_spec.lua`) to validate the asynchronous callback payload structures properly.
- All 815 unit tests pass, and luacheck verifies the codebase is 100% lint-free.
