### PR TITLE
Refactor: Move Free Space and item data queries entirely upstream to Phase 4.5

### DIFF
--- a/data/items_new.lua
+++ b/data/items_new.lua
@@ -641,6 +641,8 @@ function items:ProcessRefresh(ctx, kind)
   possibleTabs[activeTabID] = true
   possibleTabs[1] = true -- fallback
 
+  local showAll = database:GetShowAllFreeSpace(kind)
+
   for tabID in pairs(possibleTabs) do
     slotInfo.tabs[tabID] = {
       items = {},
@@ -649,6 +651,10 @@ function items:ProcessRefresh(ctx, kind)
       emptySlotsByBag = {},
       emptySlots = {},
       totalItems = 0,
+      freeSpace = {
+        showAll = showAll,
+        buttons = {},
+      },
     }
 
     -- Filter emptySlotsSorted and emptySlotsByBag for this tab
@@ -663,6 +669,53 @@ function items:ProcessRefresh(ctx, kind)
         if IncludeBagInFreeSpace(kind, bagid, tabID) then
           slotInfo.tabs[tabID].emptySlotsByBag[bagid] = { name = info.name, count = info.count }
           slotInfo.tabs[tabID].emptySlots[info.name] = (slotInfo.tabs[tabID].emptySlots[info.name] or 0) + info.count
+        end
+      end
+    end
+
+    -- Populate tabData.freeSpace.buttons
+    if showAll then
+      for _, item in ipairs(slotInfo.tabs[tabID].emptySlotsSorted) do
+        table.insert(slotInfo.tabs[tabID].freeSpace.buttons, {
+          slotkey = item.slotkey,
+          bagid = item.bagid,
+          slotid = item.slotid,
+          count = 1,
+          isIndividual = true,
+          key = item.slotkey,
+        })
+      end
+    else
+      local aggregatedCounts = {}
+      local firstSlotKeyForSubclass = {}
+      for bagid, info in pairs(slotInfo.tabs[tabID].emptySlotsByBag) do
+        aggregatedCounts[info.name] = (aggregatedCounts[info.name] or 0) + info.count
+        if not firstSlotKeyForSubclass[info.name] and slotInfo.freeSlotKeysByBag and slotInfo.freeSlotKeysByBag[bagid] then
+          firstSlotKeyForSubclass[info.name] = slotInfo.freeSlotKeysByBag[bagid]
+        end
+      end
+
+      local sortedSubclasses = {}
+      for name in pairs(aggregatedCounts) do
+        table.insert(sortedSubclasses, name)
+      end
+      table.sort(sortedSubclasses)
+
+      for _, name in ipairs(sortedSubclasses) do
+        local freeSlotCount = aggregatedCounts[name]
+        local slotKey = firstSlotKeyForSubclass[name]
+        if freeSlotCount > 0 and slotKey ~= nil then
+          local freeSlotBag, freeSlotID = slotKey:match("^(%-?%d+)_(%d+)$")
+          if freeSlotBag and freeSlotID then
+            table.insert(slotInfo.tabs[tabID].freeSpace.buttons, {
+              slotkey = slotKey,
+              bagid = tonumber(freeSlotBag),
+              slotid = tonumber(freeSlotID),
+              count = freeSlotCount,
+              isIndividual = false,
+              key = name,
+            })
+          end
         end
       end
     end

--- a/frames/bag.lua
+++ b/frames/bag.lua
@@ -412,34 +412,21 @@ function bagFrame.bagProto:DrawGlobalSections(ctx, slotInfo)
 		freeSlotsSection:SetTitle(L:G("Free Space"))
 		self.globalSections[L:G("Free Space")] = freeSlotsSection
 
-		if database:GetShowAllFreeSpace(self.kind) then
+		local freeSpaceData = tabData.freeSpace or { showAll = true, buttons = {} }
+		if freeSpaceData.showAll then
 			freeSlotsSection:SetMaxCellWidth(sizeInfo.itemsPerRow * sizeInfo.columnCount)
-			for _, item in ipairs(tabData.emptySlotsSorted or {}) do
-				local itemButton = self:GetOrCreateGlobalItemButton(ctx, item.slotkey)
-				itemButton:SetFreeSlots(ctx, item.bagid, item.slotid, 1, true)
-				freeSlotsSection:AddCell(item.slotkey, itemButton)
+			for _, btn in ipairs(freeSpaceData.buttons) do
+				local itemButton = self:GetOrCreateGlobalItemButton(ctx, btn.slotkey)
+				itemButton:SetFreeSlots(ctx, btn.bagid, btn.slotid, 1, true)
+				freeSlotsSection:AddCell(btn.slotkey, itemButton)
 			end
 			footerW, footerH = freeSlotsSection:Draw(self.kind, currentView, true, true)
 		else
 			freeSlotsSection:SetMaxCellWidth(sizeInfo.itemsPerRow)
-			local aggregatedCounts = {}
-			local firstSlotKeyForSubclass = {}
-			if tabData.emptySlotsByBag then
-				for bagid, info in pairs(tabData.emptySlotsByBag) do
-					aggregatedCounts[info.name] = (aggregatedCounts[info.name] or 0) + info.count
-					if not firstSlotKeyForSubclass[info.name] and slotInfo.freeSlotKeysByBag and slotInfo.freeSlotKeysByBag[bagid] then
-						firstSlotKeyForSubclass[info.name] = slotInfo.freeSlotKeysByBag[bagid]
-					end
-				end
-			end
-			for name, freeSlotCount in pairs(aggregatedCounts) do
-				local slotKey = firstSlotKeyForSubclass[name]
-				if freeSlotCount > 0 and slotKey ~= nil then
-					local itemButton = self:GetOrCreateGlobalItemButton(ctx, slotKey)
-					local freeSlotBag, freeSlotID = self:ParseSlotKey(slotKey)
-					itemButton:SetFreeSlots(ctx, freeSlotBag, freeSlotID, freeSlotCount)
-					freeSlotsSection:AddCell(name, itemButton)
-				end
+			for _, btn in ipairs(freeSpaceData.buttons) do
+				local itemButton = self:GetOrCreateGlobalItemButton(ctx, btn.slotkey)
+				itemButton:SetFreeSlots(ctx, btn.bagid, btn.slotid, btn.count)
+				freeSlotsSection:AddCell(btn.key, itemButton)
 			end
 			footerW, footerH = freeSlotsSection:Draw(self.kind, currentView, false)
 		end

--- a/spec/items_new_spec.lua
+++ b/spec/items_new_spec.lua
@@ -93,6 +93,7 @@ end
 database.GetCategoryFilter = function() return false end
 database.GetEnableBankBag = function() return false end
 database.GetMarkRecentItems = function() return false end
+database.GetShowAllFreeSpace = function() return true end
 
 addon.isRetail = true
 addon.isClassic = false
@@ -735,6 +736,81 @@ describe("Items (New Data Farming Engine)", function()
       groups.CategoryBelongsToGroup = originalCategoryBelongsToGroup
       categories.IsCategoryShown = originalIsCategoryShown
       _G.C_Item.GetItemInfo = savedGetItemInfo
+    end)
+
+    it("pre-evaluates Free Space settings and populates tabData.freeSpace", function()
+      -- Enable groups in Database
+      local DB = addon:GetModule("Database")
+      local originalGetGroupsEnabled = DB.GetGroupsEnabled
+      DB.GetGroupsEnabled = function() return true end
+
+      local originalGetShowAllFreeSpace = DB.GetShowAllFreeSpace
+      DB.GetShowAllFreeSpace = function(self, kind) return true end -- Test with showAll = true
+
+      -- Mock a group
+      local groups = addon:GetModule("Groups", true) or StubBetterBagsModule("Groups")
+      local originalGetAllGroups = groups.GetAllGroups
+      groups.GetAllGroups = function(self, kind)
+        return {
+          [1] = { id = 1, name = "Default Group", isDefault = true }
+        }
+      end
+
+      local originalCategoryBelongsToGroup = groups.CategoryBelongsToGroup
+      groups.CategoryBelongsToGroup = function(self, kind, category, tabID)
+        return true
+      end
+
+      -- Isolate BACKPACK_BAGS to only contain bag 0
+      local originalBackpackBags = const.BACKPACK_BAGS
+      const.BACKPACK_BAGS = { [0] = 0 }
+
+      -- Mock bags and free slots
+      local originalGetContainerNumFreeSlots = _G.C_Container.GetContainerNumFreeSlots
+      _G.C_Container.GetContainerNumFreeSlots = function(bagid)
+        if bagid == 0 then return 2 end
+        return 0
+      end
+
+      -- Mock item data
+      _G.C_Container.GetContainerNumSlots = function(bagid) return 2 end
+      _G.C_Container.GetContainerItemID = function(bagid, slotid) return nil end -- empty slots
+      _G.C_Container.GetContainerItemLink = function(bagid, slotid) return nil end
+
+      local ctx = addon:GetModule("Context"):New("TestFreeSpacePartitioning")
+      items:WipeSlotInfo(const.BAG_KIND.BACKPACK)
+      items:ProcessRefresh(ctx, const.BAG_KIND.BACKPACK)
+
+      local slotInfo = items.slotInfo[const.BAG_KIND.BACKPACK]
+
+      -- Assertions for freeSpace payload
+      assert.is_not_nil(slotInfo.tabs)
+      assert.is_not_nil(slotInfo.tabs[1])
+      assert.is_not_nil(slotInfo.tabs[1].freeSpace)
+      assert.is_true(slotInfo.tabs[1].freeSpace.showAll)
+      assert.are.equal(2, #slotInfo.tabs[1].freeSpace.buttons)
+      assert.are.equal("0_1", slotInfo.tabs[1].freeSpace.buttons[1].slotkey)
+      assert.is_true(slotInfo.tabs[1].freeSpace.buttons[1].isIndividual)
+
+      -- Now test with showAll = false
+      DB.GetShowAllFreeSpace = function(self, kind) return false end
+      items:WipeSlotInfo(const.BAG_KIND.BACKPACK)
+      items:ProcessRefresh(ctx, const.BAG_KIND.BACKPACK)
+
+      slotInfo = items.slotInfo[const.BAG_KIND.BACKPACK]
+      assert.is_not_nil(slotInfo.tabs[1].freeSpace)
+      assert.is_false(slotInfo.tabs[1].freeSpace.showAll)
+      assert.are.equal(1, #slotInfo.tabs[1].freeSpace.buttons) -- only 1 aggregated button for subclass
+      assert.is_false(slotInfo.tabs[1].freeSpace.buttons[1].isIndividual)
+      assert.are.equal(2, slotInfo.tabs[1].freeSpace.buttons[1].count)
+
+      -- Clean up mocks
+      DB.GetGroupsEnabled = originalGetGroupsEnabled
+      DB.GetShowAllFreeSpace = originalGetShowAllFreeSpace
+      _G.C_Container.GetContainerNumFreeSlots = originalGetContainerNumFreeSlots
+      groups.GetAllGroups = originalGetAllGroups
+      groups.CategoryBelongsToGroup = originalCategoryBelongsToGroup
+      const.BACKPACK_BAGS = originalBackpackBags
     end)
   end)
 

--- a/views/bagview_new.lua
+++ b/views/bagview_new.lua
@@ -10,9 +10,6 @@ local const = addon:GetModule('Constants')
 ---@class Database: AceModule
 local database = addon:GetModule('Database')
 
----@class Items: AceModule
-local items = addon:GetModule('Items')
-
 ---@class GridFrame: AceModule
 local grid = addon:GetModule('Grid')
 
@@ -85,20 +82,17 @@ local function BagView(view, ctx, bag, slotInfo, callback)
       section:AddCell(slotkey, itemButton)
       view:SetSlotSection(slotkey, section)
     else
-      local dbItem = items:GetItemDataFromSlotKey(slotkey)
-      if dbItem then
-        local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
-        if itemButton.SetItemFromData then
-          itemButton:SetItemFromData(ctx, item)
-        else
-          itemButton.staticData = item
-          itemButton:SetItem(ctx, slotkey)
-        end
-        local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
-        local section = view:GetOrCreateSection(ctx, category)
-        section:AddCell(slotkey, itemButton)
-        view:SetSlotSection(slotkey, section)
+      local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
+      if itemButton.SetItemFromData then
+        itemButton:SetItemFromData(ctx, item)
+      else
+        itemButton.staticData = item
+        itemButton:SetItem(ctx, slotkey)
       end
+      local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
+      local section = view:GetOrCreateSection(ctx, category)
+      section:AddCell(slotkey, itemButton)
+      view:SetSlotSection(slotkey, section)
     end
   end
 

--- a/views/gridview_new.lua
+++ b/views/gridview_new.lua
@@ -10,9 +10,6 @@ local const = addon:GetModule('Constants')
 ---@class Database: AceModule
 local database = addon:GetModule('Database')
 
----@class Items: AceModule
-local items = addon:GetModule('Items')
-
 ---@class GridFrame: AceModule
 local grid = addon:GetModule('Grid')
 
@@ -83,20 +80,17 @@ local function GridView(view, ctx, bag, slotInfo, callback)
       section:AddCell(slotkey, itemButton)
       view:SetSlotSection(slotkey, section)
     else
-      local dbItem = items:GetItemDataFromSlotKey(slotkey)
-      if dbItem then
-        local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
-        if itemButton.SetItemFromData then
-          itemButton:SetItemFromData(ctx, item)
-        else
-          itemButton.staticData = item
-          itemButton:SetItem(ctx, slotkey)
-        end
-        local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
-        local section = view:GetOrCreateSection(ctx, category)
-        section:AddCell(slotkey, itemButton)
-        view:SetSlotSection(slotkey, section)
+      local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
+      if itemButton.SetItemFromData then
+        itemButton:SetItemFromData(ctx, item)
+      else
+        itemButton.staticData = item
+        itemButton:SetItem(ctx, slotkey)
       end
+      local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
+      local section = view:GetOrCreateSection(ctx, category)
+      section:AddCell(slotkey, itemButton)
+      view:SetSlotSection(slotkey, section)
     end
   end
 


### PR DESCRIPTION
### Summary
This PR completes the transition of our UI views into purely data-driven 'dumb painters' by pushing the remaining Just-In-Time (JIT) view queries upstream into the Phase 4.5 data pipeline.

Specifically, this removes:
1. The redundant \`items:GetItemDataFromSlotKey(slotkey)\` lookups inside the active rendering loops of \`GridView\` and \`BagView\`.
2. The dynamic \`database:GetShowAllFreeSpace(self.kind)\` evaluation inside the global \`DrawGlobalSections\` footer renderer.

### Motivation
In previous commits, we moved tab assignments and category visibility filtering upstream into Phase 4.5. However, the view rendering phase still leaked state by dynamically querying the database for 'Show All Free Space' preferences and performing redundant item database lookups. By moving these final piece of logic upstream, \`slotInfo.tabs\` now contains the completely pre-computed UI state, including exactly how free space buttons should be drawn. The views now simply iterate and paint the exact buckets they are handed without making any external queries, ensuring a strict unidirectional, stateless rendering flow.

### Testing/Validation Performed
- **TDD Implementation:** Added new unit tests to \`spec/items_new_spec.lua\` to simulate and assert both branches of the \`GetShowAllFreeSpace\` settings directly in the pipeline generation phase.
- **Linting:** Ran \`luacheck .\` to ensure 0 warnings/errors (cleaned up unused \`items\` module imports in the views).
- **Test Suite:** Ran the full Busted test suite against Lua 5.1, resulting in 816 passing tests with zero failures.