### PR TITLE
refactor: decouple view drawing from database lookups

### DIFF
--- a/ask/plans/start/plan.md
+++ b/ask/plans/start/plan.md
@@ -1,34 +1,39 @@
-# Implementation Plan: Pure Presentation Refactor (Items 1, 2, and 4)
+# Plan: Decouple Item Rendering from Database Lookups
 
-## Overview
-This plan outlines the refactoring of the item drawing phase to strictly enforce the "Zero On-the-Fly Database Queries" rule. All required data will be pre-computed during Phase 2 (Data Farming), and pure presentation functions will have their legacy `GetItemData` fallbacks removed.
+## Objective
+Remove all remaining gaps where item buttons and views perform side-effect database lookups (`GetItemDataFromSlotKey`). The rendering layer must act purely as a functional UI that exclusively uses the `ItemData` passed from the upstream pipeline.
 
-## 1. `UpdateNewItem` & `IsBattlePayItem` (Retail)
-**Files to change:** `data/items.lua`, `data/items_new.lua`, `frames/item.lua`
+## Implementation Steps
 
-**Approach:**
-- **Phase 2 Pre-computation:** Inside `Harvest` or `GetItemDataFromInventorySlot`, safely calculate `isBattlePayItem` using `_G.C_Container.IsBattlePayItem(bagid, slotid)` (with a `nil` check for Era compatibility) and assign it to `ItemData.itemInfo.isBattlePayItem`.
-- **New Item Pre-computation:** Ensure `ItemData.itemInfo.isNewItem` accurately captures the new item status using the existing `items:IsNewItem(data)` logic during data harvesting, instead of during the draw phase.
-- **Draw Phase Simplification:** In `frames/item.lua`, update `UpdateNewItem(ctx, data)` to strictly use `data.itemInfo.isNewItem` and `data.itemInfo.isBattlePayItem`. Remove all native API queries.
+### 1. Remove `SetItem` API from Item Buttons
+- **`frames/item.lua`**:
+  - Remove `itemFrame.itemProto:SetItem(ctx, slotkey)`. It performs a side-effect `items:GetItemDataFromSlotKey(slotkey)` lookup.
+- **`frames/itemrow.lua`**:
+  - Remove the `item.itemRowProto:SetItem(ctx, data)` alias to standardize on `SetItemFromData`.
 
-## 2. Free Space / Empty Slot Bag Types
-**Files to change:** `data/items.lua`, `data/items_new.lua`, `frames/item.lua`, `frames/era/item.lua`
+### 2. Remove Fallbacks in Views and Bag Frame
+Currently, `gridview_new.lua`, `bagview_new.lua`, and `bag.lua` contain conditional logic checking if `itemButton.SetItemFromData` exists, falling back to `itemButton:SetItem`. We will hardcode `SetItemFromData` usage.
+- **`views/gridview_new.lua`**:
+  - Replace the `if itemButton.SetItemFromData then ... else ... end` block with a direct call to `itemButton:SetItemFromData(ctx, item)`.
+- **`views/bagview_new.lua`**:
+  - Apply the exact same fix.
+- **`frames/bag.lua`**:
+  - Inside `DrawGlobalSections` (for Recent Items), replace the fallback block with `itemButton:SetItemFromData(ctx, item)`.
 
-**Approach:**
-- **Phase 2 Pre-computation:** When creating an `ItemData` node for an empty slot (`isItemEmpty == true`), use the existing `items:GetBagTypeFromBagID(bagid)` logic to compute the bag's type name and quality. Store these as `data.itemInfo.emptySlotName` and `data.itemInfo.itemQuality`.
-- **Draw Phase Simplification:** Update `itemProto:SetFreeSlots(ctx, data)` in both Retail and Era item frames to read these pre-computed values directly from `data`.
-- **Cleanup:** Remove `GetBagType` and `GetBagTypeQuality` helper methods from the `itemProto`.
+### 3. Remove Dead Stacking Engine Code in `views/views.lua`
+Virtual stacking is now handled entirely upstream during Phase 3 of the data pipeline. The view-level stacking code is dead code full of database lookups.
+- **`views/views.lua`**:
+  - Delete `stackProto` and all its methods (`AddItem`, `RemoveItem`, `UpdateCount`, `GetStackCount`, `HasSubItem`, `HasAnySubItems`, `IsInStack`, `GetBackingItemData`, `IsStackEmpty`).
+  - Delete `views:NewStack(slotkey)`.
+  - Delete `views.viewProto:FlashStack(ctx, slotkey)`.
+  - Remove references to `self.stacks` in `views.viewProto:Wipe`, `views.viewProto:WipeStacks` (delete method), and `views:NewBlankView`.
 
-## 4. Legacy `GetItemData` Fallbacks and Helpers
-**Files to change:** `frames/item.lua`, `frames/era/item.lua`, `frames/itemrow.lua`
+### 4. Update Test Suite
+- **`spec/frames/item_spec.lua`**:
+  - Update tests "should clamp frame level to 0 and not throw an error after the fix" and "should call UpdateExtended on both self.button and decoration during SetItem" to use `SetItemFromData` instead of `SetItem`. This requires passing the full `itemData` mock directly.
+- **`spec/views/persistent_tabs_spec.lua`**:
+  - Update the "should reproduce the nil slotkey crash when items data is transient/nil during UpdateButton" test description and logic. The test references `itemButton:SetItem`. It should reflect `SetItemFromData` logic.
 
-**Approach:**
-- **Remove Fallbacks:** In all drawing functions within `frames/item.lua` and `frames/era/item.lua` (e.g., `UpdateCount`, `DrawItemLevel`, `UpdateUpgrade`, `UpdateCooldown`, `SetFreeSlots`, `UpdateNewItem`), remove the fallback line `data = data or self:GetItemData()`. Enforce that `data` is explicitly passed in from the upstream refresh pipeline.
-- **Refactor `itemRowProto:SetItem`:** Update `itemRowProto:SetItem(slotkey)` in `frames/itemrow.lua` to accept the `data` parameter instead of performing a live database query (`items:GetItemDataFromSlotKey(slotkey)`). Ensure the caller passes `data`.
-- **Refactor `itemFrame:RefreshItemLevelColors()`:** Modify the function so that instead of querying `items:GetItemDataFromSlotKey` for every visible frame, it relies on cached frame data or triggers a standard pipeline redraw.
-- **Refactor `IsNewItem(ctx)` Helper:** Remove the `itemFrame.itemProto:IsNewItem(ctx)` function that queries `GetItemDataFromSlotKey`, replacing its usage with direct checks against the passed `data` object.
-
-## Risks & Edge Cases
-- **Missing Data Passed to Drawings:** Removing `data = data or self:GetItemData()` will cause Lua errors if any upstream caller or external plugin invokes drawing functions without passing `data`. A thorough search for callers of these functions is required.
-- **Test Invalidation:** Existing `item_spec.lua` tests may currently rely on `itemProto` fetching its own data. Tests will need to be updated to explicitly pass the mocked `ItemData`.
-- **Classic/Era Parity:** `C_NewItems` and `C_Container.IsBattlePayItem` do not exist in Classic/Era. Conditional checks must be strictly applied in Phase 2 during data harvesting to avoid script errors.
+### 5. Verification
+- Run `luacheck .` to ensure no linting errors.
+- Run `busted .` to ensure all integration and unit tests pass.

--- a/frames/bag.lua
+++ b/frames/bag.lua
@@ -386,12 +386,7 @@ function bagFrame.bagProto:DrawGlobalSections(ctx, slotInfo)
 
 		for _, item in ipairs(recentItems) do
 			local itemButton = self:GetOrCreateGlobalItemButton(ctx, item.slotkey)
-			if itemButton.SetItemFromData then
-				itemButton:SetItemFromData(ctx, item)
-			else
-				itemButton.staticData = item
-				itemButton:SetItem(ctx, item.slotkey)
-			end
+			itemButton:SetItemFromData(ctx, item)
 			recentSection:AddCell(item.slotkey, itemButton)
 		end
 		headerW, headerH = recentSection:Draw(self.kind, currentView, false)

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -276,21 +276,6 @@ function itemFrame.itemProto:SetStaticItemFromData(ctx, data)
 	self:SetItemFromData(ctx, data)
 end
 
----@param ctx Context
----@param slotkey string
-function itemFrame.itemProto:SetItem(ctx, slotkey)
-	assert(slotkey, "item must be provided")
-	local data = items:GetItemDataFromSlotKey(slotkey)
-	if not data then
-		-- Item data can be nil when the global slotInfo was replaced by WipeSlotInfo
-		-- between when the draw was queued (via SendMessageLater) and when it fires.
-		-- Silently skip stale slotkeys rather than crashing.
-		debug:Log("SetItem", "No item data for slotkey", slotkey, "- skipping stale draw")
-		return
-	end
-	self:SetItemFromData(ctx, data)
-end
-
 ---@param item ItemButton
 ---@return integer
 function itemFrame.GetItemContextMatchResult(item)

--- a/frames/itemrow.lua
+++ b/frames/itemrow.lua
@@ -46,13 +46,6 @@ end
 
 ---@param ctx Context
 ---@param data ItemData
-function item.itemRowProto:SetItem(ctx, data)
-  assert(data, "data must be provided")
-  self:SetItemFromData(ctx, data)
-end
-
----@param ctx Context
----@param data ItemData
 ---@param static? boolean
 function item.itemRowProto:SetItemFromData(ctx, data, static)
   self.currentData = data

--- a/spec/frames/item_spec.lua
+++ b/spec/frames/item_spec.lua
@@ -172,14 +172,14 @@ describe("ItemFrame Static Buttons and Parent Removal Tests", function()
       end
     end
 
-    -- This call should succeed (it will fail right now until we implement the fix)
-    item:SetItem(btnCtx, "0_2")
+    -- This call should succeed
+    item:SetItemFromData(btnCtx, itemData)
 
     -- And the decoration frame level should be 0
     assert.equal(item._decoration._frameLevel, 0)
   end)
 
-  it("should call UpdateExtended on both self.button and decoration during SetItem", function()
+  it("should call UpdateExtended on both self.button and decoration during SetItemFromData", function()
     local btnCtx = ctx:New("test_update_extended_set_item")
     local item = itemFrame:GetButton(btnCtx, "0_3")
 
@@ -225,11 +225,11 @@ describe("ItemFrame Static Buttons and Parent Removal Tests", function()
       end
     end
 
-    item:SetItem(btnCtx, "0_3")
+    item:SetItemFromData(btnCtx, itemData)
 
     -- Assert that UpdateExtended was called on both
-    assert.equal(1, buttonUpdateExtendedCalled, "button:UpdateExtended was not called on SetItem")
-    assert.equal(1, decUpdateExtendedCalled, "decoration:UpdateExtended was not called on SetItem")
+    assert.equal(1, buttonUpdateExtendedCalled, "button:UpdateExtended was not called on SetItemFromData")
+    assert.equal(1, decUpdateExtendedCalled, "decoration:UpdateExtended was not called on SetItemFromData")
   end)
 
   it("should call UpdateExtended on both self.button and decoration during SetFreeSlots", function()

--- a/spec/views/persistent_tabs_spec.lua
+++ b/spec/views/persistent_tabs_spec.lua
@@ -180,12 +180,12 @@ end
 itemFrame.Create = function()
   local i = {
     slotkey = nil,
-    SetItem = function(self, ctx, slotkey)
-      local data = items:GetItemDataFromSlotKey(slotkey)
+    SetItemFromData = function(self, ctx, data)
       if data == nil then
         return
       end
-      self.slotkey = slotkey
+      self.slotkey = data.slotkey
+      self.staticData = data
     end,
     GetItemData = function(self)
       if self.staticData then return self.staticData end

--- a/views/bagview_new.lua
+++ b/views/bagview_new.lua
@@ -83,12 +83,7 @@ local function BagView(view, ctx, bag, slotInfo, callback)
       view:SetSlotSection(slotkey, section)
     else
       local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
-      if itemButton.SetItemFromData then
-        itemButton:SetItemFromData(ctx, item)
-      else
-        itemButton.staticData = item
-        itemButton:SetItem(ctx, slotkey)
-      end
+      itemButton:SetItemFromData(ctx, item)
       local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
       local section = view:GetOrCreateSection(ctx, category)
       section:AddCell(slotkey, itemButton)

--- a/views/gridview_new.lua
+++ b/views/gridview_new.lua
@@ -81,12 +81,7 @@ local function GridView(view, ctx, bag, slotInfo, callback)
       view:SetSlotSection(slotkey, section)
     else
       local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
-      if itemButton.SetItemFromData then
-        itemButton:SetItemFromData(ctx, item)
-      else
-        itemButton.staticData = item
-        itemButton:SetItem(ctx, slotkey)
-      end
+      itemButton:SetItemFromData(ctx, item)
       local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
       local section = view:GetOrCreateSection(ctx, category)
       section:AddCell(slotkey, itemButton)

--- a/views/views.lua
+++ b/views/views.lua
@@ -12,22 +12,11 @@ local const = addon:GetModule('Constants')
 ---@class ItemFrame: AceModule
 local itemFrame = addon:GetModule('ItemFrame')
 
----@class Items: AceModule
-local items = addon:GetModule('Items')
-
 ---@class Categories: AceModule
 local categories = addon:GetModule('Categories')
 
 ---@class Views: AceModule
 local views = addon:NewModule('Views')
-
----@class (exact) Stack
----@field item string The slotkey of the item that is rendered.
----@field swap string The slotkey of the item to swap with when marked dirty.
----@field subItems table<string, boolean> All the sub items in this stack that are not rendered.
----@field hash string The item hash for this stack.
----@field dirty boolean If the stack needs to be updated.
-local stackProto = {}
 
 ---@class (exact) View
 ---@field sections table<string, Section>
@@ -43,7 +32,6 @@ local stackProto = {}
 ---@field itemFrames Item[]
 ---@field deferredItems table<string, boolean>
 ---@field dirtySections table<string, boolean>
----@field private stacks table<string, Stack>
 ---@field WipeHandler fun(view: View, ctx: Context)
 ---@field isNew boolean
 views.viewProto = {}
@@ -83,12 +71,7 @@ function views.viewProto:Wipe(ctx)
   self.WipeHandler(self, ctx)
   self:ClearDeferredItems()
   self:ClearDirtySections()
-  wipe(self.stacks)
   wipe(self.slotToSection)
-end
-
-function views.viewProto:WipeStacks()
-  wipe(self.stacks)
 end
 
 ---@return BagView
@@ -279,28 +262,6 @@ function views.viewProto:RemoveDeferredItem(slotkey)
   self.deferredItems[slotkey] = nil
 end
 
----@param ctx Context
----@param slotkey string
-function views.viewProto:FlashStack(ctx, slotkey)
-  -- HACKFIX: Disable this for non retail clients due to
-  -- a lack of stable sort API.
-  if not addon.isRetail then return end
-
-  local item = items:GetItemDataFromSlotKey(slotkey)
-  local stack = self.stacks[item.itemHash]
-  if not stack then return end
-  items:ClearNewItem(ctx, slotkey)
-  items:ClearNewItem(ctx, stack.item)
-  for subItemSlotKey in pairs(stack.subItems) do
-    items:ClearNewItem(ctx, subItemSlotKey)
-    if self.itemsByBagAndSlot[subItemSlotKey] then
-      self.itemsByBagAndSlot[subItemSlotKey]:ClearFlashItem(ctx)
-    end
-  end
-  local itemButton = self:GetOrCreateItemButton(ctx, slotkey)
-  itemButton:FlashItem(ctx)
-end
-
 
 ---@return View
 function views:NewBlankView()
@@ -308,102 +269,8 @@ function views:NewBlankView()
     sections = {},
     itemsByBagAndSlot = {},
     deferredItems = {},
-    stacks = {},
     slotToSection = {},
     dirtySections = {},
   }, {__index = views.viewProto}) --[[@as View]]
   return view
-end
-
----@param slotkey string
----@return Stack
-function views:NewStack(slotkey)
-  local data = items:GetItemDataFromSlotKey(slotkey)
-  return setmetatable({
-    item = slotkey,
-    subItems = {},
-    hash = data.itemHash,
-    dirty = false
-  }, {__index = stackProto})
-end
-
--- AddItem adds an item to the stack. If the stack has no main item, the item is added as the main item.
--- If the stack already has a main item, the item is added as a sub item.
--- Returns true if the item was added as the main item, false if it was added as a sub item.
----@param slotkey string
----@return boolean
-function stackProto:AddItem(slotkey)
-  if self.item == nil then
-    self.item = slotkey
-    return true
-  end
-  self.subItems[slotkey] = true
-  return false
-end
-
--- RemoveItem removes an item from the stack. If the item was the main item,
--- the first sub item is promoted to the main item. If the item was a sub item,
--- it is removed from the stack. Returns the slotkey of the main item, or nil if the
--- stack is now empty.
----@param slotkey string
----@return string?
-function stackProto:RemoveItem(slotkey)
-  if self.item == slotkey then
-    self.item = nil
-    local nextkey = next(self.subItems)
-    if nextkey then
-      self.item = nextkey
-      self.subItems[nextkey] = nil
-      self:UpdateCount()
-      return nextkey
-    end
-    return nil
-  end
-
-  assert(self.subItems[slotkey], "Slotkey not found in stack" .. slotkey)
-
-  self.subItems[slotkey] = nil
-  self:UpdateCount()
-  return self.item
-end
-
-function stackProto:UpdateCount()
-  if not self.item then return end
-  local itemData = items:GetItemDataFromSlotKey(self.item)
-  if itemData.isItemEmpty then return end
-  itemData.stackedCount = itemData.itemInfo.currentItemCount
-  for subItemSlotKey in pairs(self.subItems) do
-    local subItemData = items:GetItemDataFromSlotKey(subItemSlotKey)
-    if not subItemData.isItemEmpty then
-      itemData.stackedCount = itemData.stackedCount + subItemData.itemInfo.currentItemCount
-    end
-  end
-end
-
----@return number
-function stackProto:GetStackCount()
-  if not self.item then return 0 end
-  local itemData = items:GetItemDataFromSlotKey(self.item)
-  return itemData.stackedCount
-end
-
-function stackProto:HasSubItem(slotkey)
-  return self.subItems[slotkey] ~= nil
-end
-
-function stackProto:HasAnySubItems()
-  return next(self.subItems) ~= nil
-end
-
-function stackProto:IsInStack(slotkey)
-  return self.item == slotkey or self.subItems[slotkey] ~= nil
-end
-
----@return ItemData
-function stackProto:GetBackingItemData()
-  return items:GetItemDataFromSlotKey(self.item)
-end
-
-function stackProto:IsStackEmpty()
-  return self.item == nil and next(self.subItems) == nil
 end


### PR DESCRIPTION
### Summary
- Removed the `SetItem` API from `frames/item.lua` to prevent side-effect database lookups via `GetItemDataFromSlotKey`.
- Removed `SetItem` alias from `frames/itemrow.lua` to standardize item drawing on `SetItemFromData`.
- Hardcoded `SetItemFromData` in `views/gridview_new.lua`, `views/bagview_new.lua`, and `frames/bag.lua`, fully deleting the fallback checks and the redundant fallback branch calling `SetItem`.
- Cleared dead view-level stacking engine code from `views/views.lua` (including `stackProto`, `NewStack`, and `FlashStack`) as virtual stacking is now handled strictly upstream.
- Updated the unit tests in `spec/frames/item_spec.lua` and `spec/views/persistent_tabs_spec.lua` to align with the new parameter-passing `SetItemFromData` design.

### Motivation
Historically, UI rendering components would fallback to looking up item state dynamically via `items:GetItemDataFromSlotKey(slotkey)` during view redraws. This broke the "Pure Presentation Principle" and caused out-of-order rendering state leakage. By enforcing the use of `SetItemFromData` and deleting the fallback `SetItem` code, we guarantee that the views act as dumb presentation layers that only render data passed fully resolved from the end-to-end data pipeline. It additionally allowed us to clean up old dead virtual stacking engine code from the views, as stacking is now fully handled in Phase 3 of the data pipeline.

### Testing/Validation
- **Unit & Integration Tests**: Ran `busted --lua=/usr/bin/lua .` against Lua 5.1, resulting in 820 successes and 0 failures. 
- **Linter**: Executed `luacheck .` to ensure 0 errors and 0 newly introduced warnings.
- **Code Audit**: Verified there are no remaining uses of `GetItemDataFromSlotKey` inside UI rendering paths, leaving it isolated strictly to data-processing modules and interaction handlers.