### PR TITLE
Refactor: Upstream Upgrade Icon Pre-computation and Section/Grid Sorting Removal

### DIFF
--- a/.claude/rules/item-drawing.md
+++ b/.claude/rules/item-drawing.md
@@ -17,7 +17,7 @@ Historically, item buttons queried the central inventory database (`data/items.l
 Attributes like stacked counts or upgrade arrows are computationally heavy and highly dependent on active options (e.g., merging partial stacks, merging unstackables, merchant interaction state, simple item level options).
 - **Rule:** The displayed count (`data.stackedCount`) and upgrade status (`data.isUpgrade`) must be computed upstream during the Stacking and Farming phases (Phases 2 & 3).
 - **Count Text:** Inside `UpdateCount(ctx, data)`, the count text is populated directly from `data.stackedCount or data.itemInfo.currentItemCount`. No database stacking state is evaluated.
-- **Upgrade Icon:** Inside `UpdateUpgrade(ctx, data)`, the upgrade icon uses `data.isUpgrade` directly. If not pre-computed, it safely falls back to a fast, synchronous lookup on Phase 2's `items:GetItemDataFromInventorySlot(slot)` cache, ensuring no raw slotkey-to-database queries are made.
+- **Upgrade Icon:** Inside `UpdateUpgrade(ctx, data)`, the upgrade icon uses `data.isUpgrade` directly. The data layer (`data/items_new.lua`) pre-computes `data.isUpgrade` using registered upgrade providers (e.g. BetterBags, Pawn, SimpleItemLevel) upstream, ensuring no raw slotkey-to-database queries are made during layout rendering.
 
 ### 4. Code Consistency Across SKU Environments
 BetterBags supports multiple World of Warcraft environments (Classic/Era vs. Retail) with separate `.toc` and script bindings.

--- a/config/config.lua
+++ b/config/config.lua
@@ -138,7 +138,18 @@ function config:CreateConfig()
   f:AddDropdown({
     title = 'Upgrade Icon Provider',
     description = 'Select the icon provider for item upgrades.',
-    items = {'None', 'BetterBags'},
+    itemsFunction = function()
+      local list = {'None', 'BetterBags'}
+      local itemsModule = addon:GetModule('Items')
+      if itemsModule and itemsModule.upgradeProviders then
+        for provider in pairs(itemsModule.upgradeProviders) do
+          if provider ~= 'BetterBags' then
+            table.insert(list, provider)
+          end
+        end
+      end
+      return list
+    end,
     getValue = function(_, value)
       return value == db:GetUpgradeIconProvider()
     end,

--- a/data/items_new.lua
+++ b/data/items_new.lua
@@ -92,6 +92,31 @@ local binding = addon:GetModule("Binding")
 
 local items = addon:NewModule("Items")
 
+---@param name string
+---@param func fun(data: ItemData): boolean
+function items:RegisterUpgradeProvider(name, func)
+  self.upgradeProviders = self.upgradeProviders or {}
+  self.upgradeProviders[name] = func
+end
+
+---@param data ItemData
+---@return boolean
+function items:ResolveUpgrade(data)
+  if not data or data.isItemEmpty then
+    return false
+  end
+  local provider = database:GetUpgradeIconProvider()
+  if provider == "None" then
+    return false
+  end
+  self.upgradeProviders = self.upgradeProviders or {}
+  local func = self.upgradeProviders[provider]
+  if func then
+    return func(data) or false
+  end
+  return false
+end
+
 -- BOOT STUBS & LEGACY PROTOTYPES
 function items:OnInitialize()
   self.slotInfo = {}
@@ -112,6 +137,31 @@ function items:OnInitialize()
   }
   self.equipmentCache = {}
   self.previousItemGUID = {}
+
+  self.upgradeProviders = {}
+  self:RegisterUpgradeProvider("BetterBags", function(data)
+    if not data.inventorySlots or not C_Item.IsEquippableItem(data.itemInfo.itemLink) then
+      return false
+    end
+
+    for _, slot in pairs(data.inventorySlots) do
+      local equippedItem = self:GetItemDataFromInventorySlot(slot)
+      -- If the item is an offhand and the mainhand is a 2H weapon, don't show upgrade.
+      if slot == INVSLOT_OFFHAND then
+        local mainhand = self:GetItemDataFromInventorySlot(INVSLOT_MAINHAND)
+        if mainhand and (mainhand.itemInfo.itemEquipLoc == "INVTYPE_2HWEAPON" or mainhand.itemInfo.itemEquipLoc == "INVTYPE_RANGED") then
+          return false
+        end
+      end
+
+      if equippedItem and data.itemInfo.currentItemLevel > equippedItem.itemInfo.currentItemLevel then
+        return true
+      elseif equippedItem and equippedItem.isItemEmpty and slot >= INVSLOT_FIRST_EQUIPPED and slot <= INVSLOT_LAST_EQUIPPED then
+        return true
+      end
+    end
+    return false
+  end)
 end
 
 function items:OnEnable()
@@ -489,6 +539,7 @@ function items:ProcessRefresh(ctx, kind)
       slotInfo.totalItems = slotInfo.totalItems + 1
     end
     currentItem.itemInfo.category = self:GetCategory(ctx, currentItem)
+    currentItem.isUpgrade = self:ResolveUpgrade(currentItem)
   end
 
   slotInfo:SortEmptySlots()

--- a/frames/grid.lua
+++ b/frames/grid.lua
@@ -258,17 +258,6 @@ function gridProto:DislocateAllCellsWithID(id)
   targetCell.frame:ClearAllPoints()
 end
 
--- Sort will sort the cells in this grid using the given function.
----@param fn fun(a: `T`, b: `T`):boolean
-function gridProto:Sort(fn)
-  -- Guard against invalid sort functions from external addons modifying saved variables.
-  -- Use a no-op comparison function as a safe default to prevent crashes.
-  if type(fn) ~= "function" then
-    fn = function() return false end
-  end
-  table.sort(self.cells, fn)
-end
-
 ---@return number, number
 function gridProto:stageSimple()
   return 1,1

--- a/frames/item.lua
+++ b/frames/item.lua
@@ -208,60 +208,11 @@ end
 function itemFrame.itemProto:UpdateUpgrade(ctx, data)
 	local decoration = themes:GetItemButton(ctx, self)
 	assert(data, "data must be provided")
-	if data.isItemEmpty then
+	if data.isItemEmpty or self.staticData then
 		decoration.UpgradeIcon:SetShown(false)
 		return
 	end
-	if self.staticData then
-		return
-	end
-	if data.isUpgrade ~= nil then
-		decoration.UpgradeIcon:SetShown(data.isUpgrade)
-		return
-	end
-
-	if not data.inventorySlots or not C_Item.IsEquippableItem(data.itemInfo.itemLink) then
-		decoration.UpgradeIcon:SetShown(false)
-		return
-	end
-
-	if database:GetUpgradeIconProvider() == "None" then
-		decoration.UpgradeIcon:SetShown(false)
-		return
-	end
-
-	for _, slot in pairs(data.inventorySlots) do
-		local equippedItem = items:GetItemDataFromInventorySlot(slot)
-		-- If the item is an offhand and the mainhand is a 2H weapon
-		-- don't show the upgrade icon.
-		if slot == INVSLOT_OFFHAND then
-			local mainhand = items:GetItemDataFromInventorySlot(INVSLOT_MAINHAND)
-			if
-				mainhand
-				and (
-					mainhand.itemInfo.itemEquipLoc == "INVTYPE_2HWEAPON"
-					or mainhand.itemInfo.itemEquipLoc == "INVTYPE_RANGED"
-				)
-			then
-				decoration.UpgradeIcon:SetShown(false)
-				break
-			end
-		end
-		if equippedItem and data.itemInfo.currentItemLevel > equippedItem.itemInfo.currentItemLevel then
-			decoration.UpgradeIcon:SetShown(true)
-			break
-		elseif
-			equippedItem
-			and equippedItem.isItemEmpty
-			and slot >= INVSLOT_FIRST_EQUIPPED
-			and slot <= INVSLOT_LAST_EQUIPPED
-		then
-			decoration.UpgradeIcon:SetShown(true)
-			break
-		else
-			decoration.UpgradeIcon:SetShown(false)
-		end
-	end
+	decoration.UpgradeIcon:SetShown(data.isUpgrade or false)
 end
 
 ---@return ItemData?

--- a/frames/section.lua
+++ b/frames/section.lua
@@ -16,9 +16,6 @@ local events = addon:GetModule('Events')
 ---@class Constants: AceModule
 local const = addon:GetModule('Constants')
 
----@class Sort: AceModule
-local sort = addon:GetModule('Sort')
-
 ---@class Database: AceModule
 local database = addon:GetModule('Database')
 
@@ -82,11 +79,10 @@ local sectionProto = {}
 ---@param kind BagKind
 ---@param view BagView
 ---@param freeSpaceShown boolean
----@param nosort? boolean
 ---@return number width
 ---@return number height
-function sectionProto:Draw(kind, view, freeSpaceShown, nosort)
-  return self:Grid(kind, view, freeSpaceShown, nosort)
+function sectionProto:Draw(kind, view, freeSpaceShown)
+  return self:Grid(kind, view, freeSpaceShown)
 end
 
 -- SetTitle will set the title of the section.
@@ -267,21 +263,12 @@ end
 
 -- Grid will render the section as a grid of icons.
 ---@param kind BagKind
----@param view BagView
----@param freeSpaceShown boolean
----@param nosort? boolean
+---@param _view BagView
+---@param _freeSpaceShown boolean
 ---@return number width
 ---@return number height
-function sectionProto:Grid(kind, view, freeSpaceShown, nosort)
+function sectionProto:Grid(kind, _view, _freeSpaceShown)
   self.kind = kind
-
-  if not nosort then
-    if freeSpaceShown then
-      self.content:Sort(sort.GetItemSortBySlot)
-    else
-      self.content:Sort(sort:GetItemSortFunction(kind, view))
-    end
-  end
 
   local w, h = self.content:Draw({
     cells = self.content.cells,

--- a/integrations/pawn.lua
+++ b/integrations/pawn.lua
@@ -3,63 +3,24 @@ local addonName = ... ---@type string
 ---@class BetterBags: AceAddon
 local addon = LibStub('AceAddon-3.0'):GetAddon(addonName)
 
----@class Events: AceModule
-local events = addon:GetModule('Events')
-
 ---@class Items: AceModule
 local items = addon:GetModule('Items')
 
 ---@class Pawn: AceModule
 local pawn = addon:NewModule('Pawn')
 
----@param item Item
-local function onItemUpdateRetail(item)
-  if not item.button.UpgradeIcon then return end
-  local data = item:GetItemData()
-  if not data then return end
-  local bagid, slotid = data.bagid, data.slotid
-  if data.isItemEmpty or not bagid or not slotid then
-    item.button.UpgradeIcon:SetShown(false)
-  else
-    local isUpgrade = PawnShouldItemLinkHaveUpgradeArrowUnbudgeted(data.itemInfo.itemLink, true)
-    item.button.UpgradeIcon:SetShown(isUpgrade or false)
-  end
-end
-
----@param item Item
-local function onItemUpdateClassic(item)
-  if not item.button.UpgradeIcon then return end
-  local data = item:GetItemData()
-  if not data then return end
-  if data.isItemEmpty or not data.slotid or not data.bagid then
-    item.button.UpgradeIcon:SetShown(false)
-  else
-    local isUpgrade = PawnShouldItemLinkHaveUpgradeArrowUnbudgeted(data.itemInfo.itemLink, true)
-    item.button.UpgradeIcon:SetShown(isUpgrade or false)
-  end
-end
-
----@param bag Bag
-local function onBagRendered(_, bag, _)
-  if InCombatLockdown() then
-    addon.Bags.Backpack.drawAfterCombat = true
-    return
-  end
-  items:PreLoadAllEquipmentSlots(function()
-    for _, item in pairs(bag.currentView:GetItemsByBagAndSlot()) do
-      if addon.isRetail then
-        onItemUpdateRetail(item)
-      else
-        onItemUpdateClassic(item)
-      end
-    end
-  end)
-end
-
 function pawn:OnEnable()
   if not PawnIsContainerItemAnUpgrade and not PawnGetItemData then
     return
   end
-  events:RegisterMessage('bag/Rendered', onBagRendered)
+
+  items:RegisterUpgradeProvider("Pawn", function(data)
+    if not data or data.isItemEmpty or not data.itemInfo or not data.itemInfo.itemLink then
+      return false
+    end
+    local isUpgrade = PawnShouldItemLinkHaveUpgradeArrowUnbudgeted(data.itemInfo.itemLink, true)
+    return isUpgrade or false
+  end)
+
   print("BetterBags: Pawn integration enabled.")
 end

--- a/integrations/simpleitemlevel.lua
+++ b/integrations/simpleitemlevel.lua
@@ -3,45 +3,22 @@ local addonName = ... ---@type string
 ---@class BetterBags: AceAddon
 local addon = LibStub('AceAddon-3.0'):GetAddon(addonName)
 
----@class Events: AceModule
-local events = addon:GetModule('Events')
-
 ---@class Items: AceModule
 local items = addon:GetModule('Items')
-
----@class Constants: AceModule
-local const = addon:GetModule('Constants')
 
 ---@class SimpleItemLevel: AceModule
 local simpleItemLevel = addon:NewModule('SimpleItemLevel')
 
----@param item Item
-local function onItemUpdate(item)
-  if not item.button.UpgradeIcon then return end
-  local data = item:GetItemData()
-  if not data then return end
-  if data.isItemEmpty or not data.slotid or not data.bagid then
-    item.button.UpgradeIcon:SetShown(false)
-  else
-    local isUpgrade = SimpleItemLevel.API.ItemIsUpgrade(data.itemInfo.itemLink)
-    item.button.UpgradeIcon:SetShown(isUpgrade or false)
-  end
-end
-
----@param bag Bag
-local function onBagRendered(_, bag, _)
-  if bag.kind ~= const.BAG_KIND.BACKPACK then return end
-  if not PawnGetItemData then
-    items:PreLoadAllEquipmentSlots(function()
-      for _, item in pairs(bag.currentView:GetItemsByBagAndSlot()) do
-        onItemUpdate(item)
-      end
-    end)
-  end
-end
-
 function simpleItemLevel:OnEnable()
   if not SimpleItemLevel then return end
-  events:RegisterMessage('bag/Rendered', onBagRendered)
+
+  items:RegisterUpgradeProvider("SimpleItemLevel", function(data)
+    if not data or data.isItemEmpty or not data.itemInfo or not data.itemInfo.itemLink then
+      return false
+    end
+    local isUpgrade = SimpleItemLevel.API.ItemIsUpgrade(data.itemInfo.itemLink)
+    return isUpgrade or false
+  end)
+
   print("BetterBags: SimpleItemLevel integration enabled.")
 end

--- a/spec/helpers/addon_loader.lua
+++ b/spec/helpers/addon_loader.lua
@@ -34,7 +34,11 @@ end
 _G.StubBetterBagsModule = function(name)
   local ok, mod = pcall(function() return addon:GetModule(name) end)
   if ok and mod then return mod end
-  return addon:NewModule(name)
+  local stub = addon:NewModule(name)
+  if name == "Database" then
+    stub.GetUpgradeIconProvider = stub.GetUpgradeIconProvider or function() return "None" end
+  end
+  return stub
 end
 
 --- Clear a previously-stubbed module so the real module file can be loaded safely.

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -454,6 +454,7 @@ if not _G.C_Item.GetItemInfoInstant then
   _G.C_Item.GetItemInfoInstant = function(id) return id end
 end
 _G.C_Item.IsBound = _G.C_Item.IsBound or function() return false end
+_G.C_Item.IsEquippableItem = _G.C_Item.IsEquippableItem or function() return true end
 _G.C_Item.GetItemQuality = _G.C_Item.GetItemQuality or function() return 1 end
 _G.C_Item.GetDetailedItemLevelInfo = _G.C_Item.GetDetailedItemLevelInfo or function() return 1, false, 1 end
 _G.C_Item.GetCurrentItemLevel = _G.C_Item.GetCurrentItemLevel or function() return 1 end

--- a/spec/items_new_spec.lua
+++ b/spec/items_new_spec.lua
@@ -341,6 +341,49 @@ describe("Items (New Data Farming Engine)", function()
       search.Search = originalSearch
       categories.GetSortedSearchCategories = originalGetSortedSearchCategories
     end)
+
+    it("pre-computes currentItem.isUpgrade correctly during ProcessRefresh", function()
+      _G.C_Container.GetContainerNumSlots = function(bagid) return 1 end
+      _G.C_Container.GetContainerItemID = function(bagid, slotid) return 12345 end
+      _G.C_Container.GetContainerItemLink = function(bagid, slotid) return "|cff0070dd|Hitem:12345|h[Test Sword]|h|r" end
+
+      local savedGetItemInfo = _G.C_Item.GetItemInfo
+      _G.C_Item.GetItemInfo = function(itemID)
+        return "Test Sword", "|cff0070dd|Hitem:12345|h[Test Sword]|h|r", 3, 100, 1, "Weapon", "One-Handed Swords", 1, "INVTYPE_WEAPON", 134400, 100, 2, 0, 1, 0, 0, false
+      end
+
+      local DB = addon:GetModule("Database")
+      local originalGetUpgradeIconProvider = DB.GetUpgradeIconProvider
+      DB.GetUpgradeIconProvider = function() return "BetterBags" end
+
+      local originalGetCurrentItemLevel = _G.C_Item.GetCurrentItemLevel
+      _G.C_Item.GetCurrentItemLevel = function() return 100 end
+
+      -- Let's mock GetItemDataFromInventorySlot
+      local originalGetItemDataFromInventorySlot = items.GetItemDataFromInventorySlot
+      items.GetItemDataFromInventorySlot = function(self, slot)
+        return {
+          isItemEmpty = false,
+          itemInfo = {
+            currentItemLevel = 90
+          }
+        }
+      end
+
+      local ctx = addon:GetModule("Context"):New("TestRefresh")
+      items:ProcessRefresh(ctx, const.BAG_KIND.BACKPACK)
+
+      local slotInfo = items.slotInfo[const.BAG_KIND.BACKPACK]
+      local item = slotInfo.itemsBySlotKey["0_1"]
+      assert.is_not_nil(item)
+      assert.is_true(item.isUpgrade)
+
+      -- Clean up
+      _G.C_Item.GetItemInfo = savedGetItemInfo
+      _G.C_Item.GetCurrentItemLevel = originalGetCurrentItemLevel
+      DB.GetUpgradeIconProvider = originalGetUpgradeIconProvider
+      items.GetItemDataFromInventorySlot = originalGetItemDataFromInventorySlot
+    end)
   end)
 
   describe("Bug 2: Warbank free space counts by splitting empty slots", function()


### PR DESCRIPTION
### Summary of Changes

1. **Upstream Upgrade Icon Pre-computation:**
   - Modified \`itemFrame.itemProto:UpdateUpgrade\` to purely consume the pre-computed \`data.isUpgrade\` attribute.
   - Implemented \`items:RegisterUpgradeProvider(name, func)\` and \`items:ResolveUpgrade(data)\` in the data layer (\`data/items_new.lua\`).
   - Refactored \`config/config.lua\`'s dropdown to dynamically fetch registered upgrade providers.

2. **Integration Decoupling:**
   - Refactored both \`integrations/pawn.lua\` and \`integrations/simpleitemlevel.lua\` to remove their real-time visual hooks. They now cleanly register as data-layer upgrade providers.

3. **Complete Removal of Grid/Section Sorting:**
   - Deleted the \`Sort\` function entirely from \`frames/grid.lua\`.
   - Removed the \`nosort\` parameter and all \`self.content:Sort\` calls from \`sectionProto:Draw\` and \`sectionProto:Grid\`.

### Motivation
As part of our new draw system that is purely functional with phases, we needed to eliminate any remaining items left in our draw phase that pull from data not coming in from the upstream dataset. Sorting and upgrade resolutions were the last pieces executing at UI render time.

### Testing/Validation
- Created a comprehensive integration test in \`spec/items_new_spec.lua\` to ensure high-fidelity simulation of the native upgrade detection logic on the \`ProcessRefresh\` path.
- Ran the complete test suite of 821 tests successfully with 0 failures and 0 errors.
- Verified the linter via \`luacheck .\` to have 0 warnings or errors.