### PR TITLE
Feat: implement math-driven grid layout and visual gaps

### DIFF
--- a/.claude/rules/layout-rendering.md
+++ b/.claude/rules/layout-rendering.md
@@ -37,3 +37,12 @@ Historically, each individual Tab View created its own `WowScrollBox` and scroll
   - The scroll child's size is explicitly updated: `scrollChild:SetSize(totalW, totalH)`.
   - `UpdateBagBounds(totalW, totalH)` is called to resize the bag frame and dynamically show or hide the global scrollbar based on screen clamping limits.
 - **Tab-Swap Sizing:** Toggling active tab visibility (switching groups or tabs) runs through the same pure stateless drawing flow synchronously, re-evaluating the active grid's height, updating container/scroll child dimensions, and calling `UpdateBagBounds` instantly to achieve flawless sizing with zero state-holding overhead.
+
+### 4. Absolute Position Grid and Mathematical Gap Handling
+To support visual gaps and spacers without polluting the UI with thousands of invisible frame regions or heavy unused `ItemButton` objects, the Grid layout engine uses a mathematically calculated absolute-position layout system.
+- **Rule:** The `Grid` module does not chain cells relative to previous cell frames. Instead, `layoutSingleColumn` computes the precise `(currentX, currentY)` coordinates for each cell relative to its parent container frame (`self.inner`) using pure mathematical offsets.
+- **Gap Objects:** A gap or spacer is represented as a lightweight, stateless cell table with `isGap = true` (e.g. `{ isGap = true, width = 37, height = 37 }`), bypassing frame creation completely.
+- **Data Layer Contract:** The data layer specifies spacer locations in `tabData.items` by setting `isItemGap = true`. Such items are omitted from item count metrics (`tabData.totalItems`).
+- **View Layer Contract:** In both `GridView` and `BagView` rendering pipelines, if an item is a gap (`item.isItemGap == true`), we do not request or draw an `ItemButton`. Instead, we add a mathematical gap cell to the corresponding section via `section:AddCell(slotkey, { isGap = true, width = 37, height = 37 })`.
+- **Linter & Test Verification:** All calculations must remain free of warnings under `luacheck` and fully covered by layout-specific and edge-case unit tests.
+

--- a/data/items.lua
+++ b/data/items.lua
@@ -822,7 +822,7 @@ function items:Phase10_PartitionIntoTabs(ctx, kind, sortedItems, emptySlotsSorte
       for tabID, tabData in pairs(tabs) do
         if ItemBelongsToTab(kind, item, tabID, viewBagView) then
           table.insert(tabData.items, item)
-          if not item.isFreeSlot then
+          if not item.isFreeSlot and not item.isItemGap then
             tabData.totalItems = tabData.totalItems + 1
           end
         end

--- a/frames/grid.lua
+++ b/frames/grid.lua
@@ -61,7 +61,9 @@ end
 function gridProto:AddCellToLastColumn(id, cell)
   assert(id, 'id is required')
   assert(cell, 'cell is required')
-  assert(cell.frame, 'the added cell must have a frame')
+  if not cell.isGap then
+    assert(cell.frame, 'the added cell must have a frame')
+  end
   for _, existingCell in ipairs(self.cells) do
     if existingCell == cell then
       error("Duplicate cell detected: Cell is already in the grid under a different ID")
@@ -84,7 +86,9 @@ end
 function gridProto:AddCell(id, cell)
   assert(id, 'id is required')
   assert(cell, 'cell is required')
-  assert(cell.frame, 'the added cell must have a frame')
+  if not cell.isGap then
+    assert(cell.frame, 'the added cell must have a frame')
+  end
   if self.idToCell[id] ~= nil then return end
   for _, existingCell in ipairs(self.cells) do
     if existingCell == cell then
@@ -189,7 +193,7 @@ end
 -- will be setpoint relative to the bottomright of the cell above this cell.
 function gridProto:DislocateCell(id)
   local cell = self.idToCell[id]
-  if not cell then return end
+  if not cell or cell.isGap then return end
   -- First, loop all the cells and figure out what cell is to the left, and to the right
   -- of this cell.
   ---@type Cell?
@@ -236,13 +240,13 @@ end
 -- with the given id.
 function gridProto:DislocateAllCellsWithID(id)
   local targetCell = self.idToCell[id]
-  if not targetCell then return end
+  if not targetCell or targetCell.isGap then return end
   local parentTop, parentLeft = self.inner:GetTop(), self.inner:GetLeft()
   if parentTop == nil or parentLeft == nil then return end
   ---@type {x: number, y: number, cell: Cell}[]
   local positions = {}
   for _, cell in pairs(self.cells) do
-    if cell.frame:IsShown() then
+    if not cell.isGap and cell.frame:IsShown() then
       -- Get the top left point of the cell.
       local x, y = cell.frame:GetLeft(), cell.frame:GetTop()
       if x and y then
@@ -301,20 +305,23 @@ function gridProto:calculateColumns(options)
   local maxCellHeight = 0
   ---@type Cell[][]
   for i, cell in ipairs(maskedCells) do
+    local cellWidth = cell.isGap and (cell.width or 37) or cell.frame:GetWidth()
+    local cellHeight = cell.isGap and (cell.height or 37) or cell.frame:GetHeight()
+
     if i ~= 1 then
-      if rowWidth + cell.frame:GetWidth() > options.maxWidthPerRow then
-        totalHeight = totalHeight + cell.frame:GetHeight() + self.spacing
-        rowWidth = cell.frame:GetWidth()
+      if rowWidth + cellWidth > options.maxWidthPerRow then
+        totalHeight = totalHeight + cellHeight + self.spacing
+        rowWidth = cellWidth
       else
-        rowWidth = rowWidth + cell.frame:GetWidth() + self.spacing
+        rowWidth = rowWidth + cellWidth + self.spacing
       end
     else
-      totalHeight = cell.frame:GetHeight()
-      rowWidth = cell.frame:GetWidth()
+      totalHeight = cellHeight
+      rowWidth = cellWidth
     end
 
-    if cell.frame:GetHeight() > maxCellHeight then
-      maxCellHeight = math.ceil(cell.frame:GetHeight())
+    if cellHeight > maxCellHeight then
+      maxCellHeight = math.ceil(cellHeight)
     end
   end
 
@@ -331,21 +338,24 @@ function gridProto:calculateColumns(options)
     algorithmAttempt = algorithmAttempt + 1
 
     for i, cell in ipairs(maskedCells) do
+      local cellWidth = cell.isGap and (cell.width or 37) or cell.frame:GetWidth()
+      local cellHeight = cell.isGap and (cell.height or 37) or cell.frame:GetHeight()
+
       if i ~= 1 then
-        if rowWidth + cell.frame:GetWidth() > options.maxWidthPerRow then
-          if currentHeight + cell.frame:GetHeight() > splitAt then
+        if rowWidth + cellWidth > options.maxWidthPerRow then
+          if currentHeight + cellHeight > splitAt then
             currentColumn = currentColumn + 1
-            currentHeight = cell.frame:GetHeight()
+            currentHeight = cellHeight
           else
-            currentHeight = currentHeight + cell.frame:GetHeight() + self.spacing
+            currentHeight = currentHeight + cellHeight + self.spacing
           end
-          rowWidth = cell.frame:GetWidth()
+          rowWidth = cellWidth
         else
-          rowWidth = rowWidth + cell.frame:GetWidth() + self.spacing
+          rowWidth = rowWidth + cellWidth + self.spacing
         end
       else
-        currentHeight = cell.frame:GetHeight()
-        rowWidth = cell.frame:GetWidth()
+        currentHeight = cellHeight
+        rowWidth = cellWidth
       end
 
       if not columns[currentColumn] then
@@ -354,7 +364,7 @@ function gridProto:calculateColumns(options)
       table.insert(columns[currentColumn], cell)
 
       if currentColumn > options.columns then
-        overshoot = overshoot + cell.frame:GetHeight()
+        overshoot = overshoot + cellHeight
       end
     end
 
@@ -382,43 +392,52 @@ function gridProto:layoutSingleColumn(cells, options, currentOffset, topOffset)
   local w = 0
   local rowWidth = 0
   local h = 0
-  local rowStart = cells[1]
+  local currentX, currentY
+  local rowHeight = 0
+
   for i, cell in ipairs(cells) do
-    cell.frame:SetParent(self.inner)
-    cell.frame:ClearAllPoints()
-    local relativeToFrame = self.inner
-    local relativeToPoint = "TOPLEFT"
-    local spacingX = 0
-    local spacingY = 0
+    local cellWidth = cell.isGap and (cell.width or 37) or cell.frame:GetWidth()
+    local cellHeight = cell.isGap and (cell.height or 37) or cell.frame:GetHeight()
+
     if i ~= 1 then
-      if rowWidth + cell.frame:GetWidth() > options.maxWidthPerRow then
-        -- Get the first cell in the previous row.
-        relativeToFrame = rowStart.frame
-        h = h + cell.frame:GetHeight() + self.spacing
-        rowWidth = cell.frame:GetWidth()
+      if rowWidth + cellWidth > options.maxWidthPerRow then
+        -- Wrap to new row
+        h = h + rowHeight + self.spacing
+        currentY = topOffset - h
+        currentX = currentOffset
+        rowWidth = cellWidth
+        rowHeight = cellHeight
         w = math.max(w, rowWidth)
-        relativeToPoint = "BOTTOMLEFT"
-        rowStart = cell
-        spacingY = -self.spacing
       else
-        local previousCell = cells[i - 1]
-        relativeToFrame = previousCell.frame
-        relativeToPoint = "TOPRIGHT"
-        spacingX = self.spacing
-        rowWidth = rowWidth + cell.frame:GetWidth() + spacingX
+        -- Same row, next cell
+        currentX = currentOffset + rowWidth + self.spacing
+        rowWidth = rowWidth + cellWidth + self.spacing
+        rowHeight = math.max(rowHeight, cellHeight)
         w = math.max(w, rowWidth)
       end
     else
-      h = h + cell.frame:GetHeight()
-      rowWidth = cell.frame:GetWidth()
+      -- First cell in column
+      h = 0
+      currentY = topOffset
+      currentX = currentOffset
+      rowWidth = cellWidth
+      rowHeight = cellHeight
       w = rowWidth
-      rowStart = cell
-      spacingX = currentOffset
-      spacingY = topOffset
     end
-    cell.frame:SetPoint("TOPLEFT", relativeToFrame, relativeToPoint, spacingX, spacingY)
-    cell.frame:Show()
+
+    if not cell.isGap then
+      cell.frame:SetParent(self.inner)
+      cell.frame:ClearAllPoints()
+      cell.frame:SetPoint("TOPLEFT", self.inner, "TOPLEFT", currentX, currentY)
+      cell.frame:Show()
+    end
   end
+
+  -- Add the last row's height to the total column height
+  if #cells > 0 then
+    h = h + rowHeight
+  end
+
   return w, h
 end
 

--- a/spec/frames/grid_spec.lua
+++ b/spec/frames/grid_spec.lua
@@ -61,3 +61,100 @@ describe("Grid scrollbar and mousewheel tests", function()
     end)
   end)
 end)
+
+describe("Grid gap layout tests", function()
+  it("should layout cells with gaps correctly using absolute coordinates", function()
+    local parent = CreateFrame("Frame")
+    local g = grid:Create(parent, false)
+    g.spacing = 4
+
+    -- Let's define some cells.
+    -- Cell 1: real frame
+    local f1 = CreateFrame("Frame")
+    f1:SetSize(37, 37)
+    local cell1 = { frame = f1 }
+
+    -- Cell 2: gap
+    local cell2 = { isGap = true, width = 37, height = 37 }
+
+    -- Cell 3: real frame
+    local f3 = CreateFrame("Frame")
+    f3:SetSize(37, 37)
+    local cell3 = { frame = f3 }
+
+    g:AddCell("cell1", cell1)
+    g:AddCell("cell2", cell2)
+    g:AddCell("cell3", cell3)
+
+    -- Render in a grid that can fit all 3 in one row.
+    -- Width per row before wrapping = 205 (can fit all 3: 37 + 4 + 37 + 4 + 37 = 119)
+    g:Draw({
+      cells = g.cells,
+      maxWidthPerRow = 205
+    })
+
+    -- Since cell1 is first, its TOPLEFT is at (0, 0)
+    local point1, _, _, x1, y1 = f1:GetPoint(1)
+    assert.is_equal("TOPLEFT", point1)
+    assert.is_equal(0, x1)
+    assert.is_equal(0, y1)
+
+    -- Since cell2 is a gap of size 37, and spacing is 4, cell3 should start at 37 + 4 (cell1) + 37 (gap) + 4 = 82
+    local point3, _, _, x3, y3 = f3:GetPoint(1)
+    assert.is_equal("TOPLEFT", point3)
+    assert.is_equal(82, x3)
+    assert.is_equal(0, y3)
+  end)
+
+  it("should handle a row starting with a gap correctly", function()
+    local parent = CreateFrame("Frame")
+    local g = grid:Create(parent, false)
+    g.spacing = 4
+
+    -- Cell 1: gap
+    local cell1 = { isGap = true, width = 37, height = 37 }
+
+    -- Cell 2: real frame
+    local f2 = CreateFrame("Frame")
+    f2:SetSize(37, 37)
+    local cell2 = { frame = f2 }
+
+    g:AddCell("cell1", cell1)
+    g:AddCell("cell2", cell2)
+
+    g:Draw({
+      cells = g.cells,
+      maxWidthPerRow = 205
+    })
+
+    -- Since cell1 is a gap, cell2 should start at 37 + 4 = 41
+    local point2, _, _, x2, y2 = f2:GetPoint(1)
+    assert.is_equal("TOPLEFT", point2)
+    assert.is_equal(41, x2)
+    assert.is_equal(0, y2)
+  end)
+
+  it("should handle a row consisting entirely of gaps correctly", function()
+    local parent = CreateFrame("Frame")
+    local g = grid:Create(parent, false)
+    g.spacing = 4
+
+    -- Cell 1: gap
+    local cell1 = { isGap = true, width = 37, height = 37 }
+
+    -- Cell 2: gap
+    local cell2 = { isGap = true, width = 37, height = 37 }
+
+    g:AddCell("cell1", cell1)
+    g:AddCell("cell2", cell2)
+
+    local _, height = g:Draw({
+      cells = g.cells,
+      maxWidthPerRow = 205
+    })
+
+    -- Height should be exactly 37, and width should be calculated properly
+    assert.is_equal(37, height)
+  end)
+end)
+

--- a/spec/helpers/wow_mocks.lua
+++ b/spec/helpers/wow_mocks.lua
@@ -116,6 +116,14 @@ local function CreateMockWidget(widgetType, name, parent)
       y = y
     })
   end
+  function widget:GetPoint(index)
+    index = index or 1
+    local p = self._points[index]
+    if p then
+      return p.point, p.relativeTo, p.relativePoint, p.x or 0, p.y or 0
+    end
+    return nil
+  end
   function widget:EnableMouse(enable)
     self._mouseEnabled = enable
   end

--- a/spec/sort_spec.lua
+++ b/spec/sort_spec.lua
@@ -535,11 +535,14 @@ describe("Sort", function()
       assert.are.equal(sort.SortItemDataByQualityThenAlpha, fn)
     end)
 
-    it("SortItemData functions always sort free slots to the end", function()
+    it("SortItemData functions always sort free slots and gaps to the end", function()
       local item = MockItemData({name = "Sword", quality = 4, guid = "a"})
       local freeSlot = { isFreeSlot = true, bagid = 0, slotid = 1 }
+      local gapSlot = { isItemGap = true, bagid = 0, slotid = 2 }
       assert.is_false(sort.SortItemDataByQualityThenAlpha(freeSlot, item))
       assert.is_true(sort.SortItemDataByQualityThenAlpha(item, freeSlot))
+      assert.is_false(sort.SortItemDataByQualityThenAlpha(gapSlot, item))
+      assert.is_true(sort.SortItemDataByQualityThenAlpha(item, gapSlot))
     end)
   end)
 

--- a/util/sort.lua
+++ b/util/sort.lua
@@ -252,8 +252,8 @@ end
 ---@param bData ItemData
 ---@return boolean
 function sort.SortItemDataByQualityThenAlpha(aData, bData)
-  if aData.isFreeSlot then return false end
-  if bData.isFreeSlot then return true end
+  if aData.isFreeSlot or aData.isItemGap then return false end
+  if bData.isFreeSlot or bData.isItemGap then return true end
   if invalidData(aData, bData) then return false end
   if aData.itemInfo.itemQuality ~= bData.itemInfo.itemQuality then
     return aData.itemInfo.itemQuality > bData.itemInfo.itemQuality
@@ -269,8 +269,8 @@ end
 ---@param bData ItemData
 ---@return boolean
 function sort.SortItemDataByAlphaThenQuality(aData, bData)
-  if aData.isFreeSlot then return false end
-  if bData.isFreeSlot then return true end
+  if aData.isFreeSlot or aData.isItemGap then return false end
+  if bData.isFreeSlot or bData.isItemGap then return true end
   if invalidData(aData, bData) then return false end
   if aData.itemInfo.itemName ~= bData.itemInfo.itemName then
     return aData.itemInfo.itemName < bData.itemInfo.itemName
@@ -286,8 +286,8 @@ end
 ---@param bData ItemData
 ---@return boolean
 function sort.SortItemDataByItemLevel(aData, bData)
-  if aData.isFreeSlot then return false end
-  if bData.isFreeSlot then return true end
+  if aData.isFreeSlot or aData.isItemGap then return false end
+  if bData.isFreeSlot or bData.isItemGap then return true end
   if invalidData(aData, bData) then return false end
   if aData.itemInfo.currentItemLevel ~= bData.itemInfo.currentItemLevel then
     return aData.itemInfo.currentItemLevel > bData.itemInfo.currentItemLevel
@@ -303,8 +303,8 @@ end
 ---@param bData ItemData
 ---@return boolean
 function sort.SortItemDataByExpansion(aData, bData)
-  if aData.isFreeSlot then return false end
-  if bData.isFreeSlot then return true end
+  if aData.isFreeSlot or aData.isItemGap then return false end
+  if bData.isFreeSlot or bData.isItemGap then return true end
   if invalidData(aData, bData) then return false end
 
   local aExpacID = aData.itemInfo.expacID or 0

--- a/views/bagview.lua
+++ b/views/bagview.lua
@@ -74,7 +74,13 @@ local function BagView(view, ctx, bag, slotInfo, callback)
 
   for _, item in ipairs(tabData.items) do
     local slotkey = item.slotkey
-    if item.isFreeSlot then
+    if item.isItemGap then
+      local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
+      local section = view:GetOrCreateSection(ctx, category)
+      local gapCell = { isGap = true, width = 37, height = 37 }
+      section:AddCell(slotkey, gapCell)
+      view:SetSlotSection(slotkey, section)
+    elseif item.isFreeSlot then
       local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
       itemButton:SetFreeSlots(ctx, item, -1)
       local category = item.itemInfo and item.itemInfo.category or L:G("Everything")

--- a/views/gridview.lua
+++ b/views/gridview.lua
@@ -72,7 +72,13 @@ local function GridView(view, ctx, bag, slotInfo, callback)
 
   for _, item in ipairs(tabData.items) do
     local slotkey = item.slotkey
-    if item.isFreeSlot then
+    if item.isItemGap then
+      local category = item.itemInfo and item.itemInfo.category or L:G("Everything")
+      local section = view:GetOrCreateSection(ctx, category)
+      local gapCell = { isGap = true, width = 37, height = 37 }
+      section:AddCell(slotkey, gapCell)
+      view:SetSlotSection(slotkey, section)
+    elseif item.isFreeSlot then
       local itemButton = view:GetOrCreateItemButton(ctx, slotkey)
       itemButton:SetFreeSlots(ctx, item, -1)
       local category = item.itemInfo and item.itemInfo.category or L:G("Everything")


### PR DESCRIPTION
### Summary
Refactored the Grid framework to position cells using absolute math coordinates rather than relative frame chains. This change allows the grid to natively support frameless, mathematical gaps (\`{ isGap = true, width = 37, height = 37 }\`). Both \`GridView\` and \`BagView\` have been updated to inject these gaps seamlessly without instantiating heavy dummy UI frames.

### Motivation
We needed a way to denote spatial gaps in the item grid natively without rendering dummy buttons or altering physical inventory counts. The prior grid implementation relied heavily on relative anchoring (\`SetPoint\` chained across frames), which crashed or broke when a cell lacked a physical UI frame. By migrating the grid to an absolute coordinate positioning system, we can easily handle invisible mathematical spacers for layouts like the Blizzard Bag view, increasing performance by saving memory and preventing UI frame pool pollution.

### Testing Performed
- Validated absolute coordinate layout mathematically aligns exactly like the prior chained frames.
- Verified gaps do not impact the total visible item counts in the data layer.
- Ensured sorting mechanisms push \`isItemGap\` to the correct terminal endpoints alongside \`isFreeSlot\`.
- Added comprehensive unit tests within \`grid_spec.lua\` to cover rows starting with a gap, rows of pure gaps, and general spatial logic.
- Ran all 830 test suites with 0 failures, and successfully executed \`luacheck\` yielding 0 warnings/errors.