### PR TITLE
fix(money): refresh backpack money on PLAYER_ENTERING_WORLD

### DIFF
--- a/frames/money.lua
+++ b/frames/money.lua
@@ -94,6 +94,14 @@ function money:Create(warbank)
   events:RegisterEvent("PLAYER_MONEY", function()
     m:Update()
   end)
+  -- The frame is built during ADDON_LOADED (core/init.lua -> BagFrame:Create),
+  -- when GetMoney() still returns 0 because player data has not loaded yet.
+  -- PLAYER_MONEY does not fire on login (the amount did not change), so without
+  -- this the frame would display a stale 0 until money next changes. Refresh once
+  -- the world finishes loading (login and /reload) so the real amount is shown.
+  events:RegisterEvent("PLAYER_ENTERING_WORLD", function()
+    m:Update()
+  end)
   return m
 end
 

--- a/spec/frames/money_spec.lua
+++ b/spec/frames/money_spec.lua
@@ -75,6 +75,33 @@ describe("Money Frame", function()
     end)
   end)
 
+  describe("Login timing", function()
+    it("refreshes stale money once the player finishes entering the world", function()
+      -- On a fresh login the money frame is built during ADDON_LOADED (see
+      -- core/init.lua -> BagFrame:Create -> SetupMoneyFrame -> money:Create),
+      -- at which point GetMoney() still returns 0 because player data has not
+      -- loaded yet.
+      _G._playerMoney = 0
+      local m = money:Create(false)
+      -- Reproduces the reported bug: the frame shows 0/0/0 like the screenshot.
+      assert.are.equal(m.goldButton:GetText(), "0")
+      assert.are.equal(m.silverButton:GetText(), "0")
+      assert.are.equal(m.copperButton:GetText(), "0")
+
+      -- Player data becomes available and the world finishes loading. PLAYER_MONEY
+      -- does NOT fire on login (the amount did not change), so the money frame must
+      -- refresh itself on PLAYER_ENTERING_WORLD or it will display a stale 0 forever.
+      _G._playerMoney = 1234567 -- 123 gold, 45 silver, 67 copper
+      local handler = events._eventMap["PLAYER_ENTERING_WORLD"]
+      assert.is_not_nil(handler) -- money frame must listen for login completion
+      handler.fn()
+
+      assert.are.equal(m.goldButton:GetText(), "123")
+      assert.are.equal(m.silverButton:GetText(), "45")
+      assert.are.equal(m.copperButton:GetText(), "67")
+    end)
+  end)
+
   describe("Mouse Interactions and Popups", function()
     it("shows PICKUP_MONEY popup on left-clicking standard frame", function()
       local m = money:Create(false)


### PR DESCRIPTION
## Problem
On a fresh login, the backpack money display was stuck at **0 / 0 / 0** even for characters with money.

## Root cause
The money frame is built during `ADDON_LOADED` via `core/init.lua` → `BagFrame:Create` → `backpack.proto:SetupMoneyFrame` → `money:Create` (`frames/money.lua`). `money:Create` immediately calls `m:Update()`, which reads `GetMoney()` — but at `ADDON_LOADED` the player's data isn't loaded yet, so `GetMoney()` returns `0` and the frame caches "0/0/0".

The frame only re-updated on `PLAYER_MONEY`, which does **not** fire at login (the amount hasn't changed). So the display stayed at 0 until the player's money next changed. The bank money frame doesn't hit this because `bags/bank.lua` explicitly calls `moneyFrame:Update()` when the bank opens; the backpack had no equivalent refresh.

## Fix
Register `PLAYER_ENTERING_WORLD` in `money:Create` so the frame refreshes once the world finishes loading (covers both login and `/reload`), mirroring the bank's on-open refresh. `Update()` is cheap, so the extra fires on zone transitions are harmless.

## Test (added first, per test-first policy)
`spec/frames/money_spec.lua` → "Login timing": builds the frame while `GetMoney()` returns 0 (asserts the 0/0/0 state), then fires `PLAYER_ENTERING_WORLD` after money becomes available and asserts the real amount is shown. Fails before the fix (no `PLAYER_ENTERING_WORLD` handler registered), passes after.

## Verification
- Money spec: 12/12 pass
- Full suite (Lua 5.1): 899/899 pass
- `luacheck .`: 0 warnings / 0 errors in 152 files